### PR TITLE
Stage Circular Dependency correction, Class Stubs needed for Stage added, Documentation and Minor corrections

### DIFF
--- a/src/Error.as
+++ b/src/Error.as
@@ -17,7 +17,7 @@ package
          super();
          this.message = message;
          this._errorID = id;
-         this.name ;
+         this.name = "";
       }
       
      public static function getErrorMessage(param1:int) : String{return null}

--- a/src/flash/accessibility/AccessibilityImplementation.as
+++ b/src/flash/accessibility/AccessibilityImplementation.as
@@ -1,0 +1,392 @@
+package flash.accessibility
+{
+	import flash.geom.Rectangle;
+
+	/**
+	 * The AccessibilityImplementation class is the base class in Flash Player
+	 * that allows for the implementation of accessibility in components. 
+	 * This class enables communication between a component and a screen reader. 
+	 * Screen readers are used to translate screen content into synthesized speech 
+	 * or braille for visually impaired users.
+	 * 
+	 *   <p class="- topic/p ">The AccessibilityImplementation class provides a set of methods that allow a component
+	 * developer to make information about system roles, object based events, and states available
+	 * to assistive technology.</p><p class="- topic/p ">Adobe Flash Player uses Microsoft Active Accessibility (MSAA), which provides a descriptive
+	 * and standardized way for applications and screen readers to communicate. For more information
+	 * on how the Flash Player works with MSAA, see the accessibility chapter in <i class="+ topic/ph hi-d/i ">Using Flex SDK</i>.</p><p class="- topic/p ">The methods of the AccessibilityImplementation class are a subset of the 
+	 * <xref href="http://msdn.microsoft.com/en-us/library/ms696097(VS.85).aspx" class="- topic/xref ">IAccessible</xref> interface
+	 * for a component instance.</p><p class="- topic/p ">The way that an AccessibilityImplementation implements the IAccessible interface, 
+	 * and the events that it sends, depend on the kind of component being implemented.</p><p class="- topic/p ">Do not directly instantiate AccessibilityImplementation by calling its constructor.
+	 * Instead, create new accessibility implementations by extending the 
+	 * AccImpl class for each new component.
+	 * In Flash, see the fl.accessibility package. 
+	 * In Flex, see the mx.accessibility package and 
+	 * the accessibility chapter in <i class="+ topic/ph hi-d/i ">Using Flex SDK</i>.</p><p class="- topic/p "><b class="+ topic/ph hi-d/b ">Note:</b> The AccessibilityImplementation class is not supported in AIR runtime versions before AIR 2. The class is
+	 * available for compilation in AIR versions before AIR 2, but is not supported in the runtime until AIR 2.</p>
+	 * @playerversion	Flash 9
+	 * @playerversion	AIR 2
+	 */
+	public class AccessibilityImplementation extends Object
+	{
+		/**
+		 * Indicates an error code. Errors are indicated out-of-band, rather than in return values. 
+		 * To indicate an error, set the errno property to one of the error codes
+		 * documented in the AccessibilityImplementation Constants appendix. 
+		 * This causes your return value to be ignored. The errno property
+		 * of your AccessibilityImplementation is always cleared (set to zero) by the player
+		 * before any AccessibilityImplementation method is called.
+		 * @playerversion	Flash 9
+		 * @playerversion	AIR 2
+		 */
+		public var errno:uint;
+
+		/**
+		 * Used to create a component accessibility stub.
+		 * If a component is released without an ActionScript accessibility implementation,
+		 * Adobe recommends that you add a component accessibility stub. 
+		 * This stub causes Flash Player, for accessibility purposes, to treat the component
+		 * as a simple graphic rather than exposing the internal structure of buttons,
+		 * textfields, and so on, within the component.
+		 * 
+		 *   To create a component accessibility stub,
+		 * subclass the relevant AccImpl class, overriding the property stub
+		 * with a value of true.
+		 * @playerversion	Flash 9
+		 * @playerversion	AIR 2
+		 */
+		public var stub:Boolean;
+
+		/**
+		 * An IAccessible method that performs the default action associated with the component
+		 * that this AccessibilityImplementation represents or of one of its child elements.
+		 * 
+		 *   Implement this method only if the AccessibilityImplementation represents a UI element
+		 * that has a default action in the MSAA model.If you are implementing accDoDefaultAction() only for the AccessibilityImplementation
+		 * itself, or only for its child elements, you will need in some cases to indicate that there
+		 * is no default action for the particular childID that was passed. 
+		 * Do this by setting the errno property to E_MEMBERNOTFOUND.
+		 * @param	childID	An unsigned integer corresponding to one of the component's child elements,
+		 *   as defined by getChildIDArray().
+		 * @playerversion	Flash 9
+		 * @playerversion	AIR 2
+		 */
+		public function accDoDefaultAction (childID:uint):void
+		{
+			
+		}
+
+		/**
+		 * Static constructor. Do not directly instantiate AccessibilityImplementation by calling its constructor.
+		 * Instead, create new accessibility implementations by extending the mx.accessibility.AccImpl
+		 * class for each new component.
+		 * @playerversion	Flash 9
+		 * @playerversion	AIR 2
+		 */
+		public function AccessibilityImplementation()
+		{
+			
+		}
+
+		/**
+		 * MSAA method for returning a DisplayObject or Rectangle
+		 * specifying the bounding box of a child element in the AccessibilityImplementation.
+		 * 
+		 *   This method is never called with a childID of zero. 
+		 * If your AccessibilityImplementation will never contain child elements, you should not implement 
+		 * this method. If your AccessibilityImplementation can contain child elements, 
+		 * this method is mandatory.You can usually satisfy the requirements of this method by returning an 
+		 * object that represents the child element itself. This works as long as the 
+		 * child element is a DisplayObject. 
+		 * In these cases, simply return the DisplayObject that corresponds to 
+		 * the instance name associated with the relevant visual object in display list.If a child element does not qualify for the technique described above, 
+		 * you may do the bounding-box math yourself and return a Rectangle with:
+		 * x, y, width, and height properties. 
+		 * The x and y members specify the upper-left corner of the bounding box, and 
+		 * the width and height members specify its size. All four members 
+		 * should be in units of Stage pixels, and relative to the origin of the component 
+		 * that the AccessibilityImplementation represents. The x and y properties may have 
+		 * negative values, since the origin of a DisplayObject is not necessarily in its 
+		 * upper-left corner.If the child element specified by childID is not visible (that is, get_accState 
+		 * for that child would return a value including STATE_SYSTEM_INVISIBLE), you 
+		 * may return null from accLocation. You can also 
+		 * return a Rectangle representing the coordinates where the child element would 
+		 * appear if it were visible.
+		 * @param	childID	An unsigned integer corresponding to one of the component's child elements
+		 *   as defined by getChildIDArray().
+		 * @return	DisplayObject or Rectangle specifying the bounding box
+		 *   of the child element specified by childID parameter.
+		 * @playerversion	Flash 9
+		 * @playerversion	AIR 2
+		 */
+		public function accLocation (childID:uint):*
+		{
+			return null;
+		}
+
+		/**
+		 * IAccessible method for altering the selection in the component 
+		 * that this AccessibilityImplementation represents.
+		 * 
+		 *   The childID parameter will always be nonzero. This method 
+		 * always applies to a child element rather than the overall component; 
+		 * Flash Player manages the selection of the overall component itself.The selFlag parameter is a bitfield consisting of one or more selection flag constants
+		 * that allows an MSAA client to indicate how the item referenced by the childID 
+		 * should be selected or take focus. What follows are descriptions of the selection flag constants
+		 * and what they communicate to the accessibility implementation.  
+		 * As a practical matter, most implementations of this method in accessibility implementations
+		 * that inherit from the Flex mx.accessibility.ListBaseAccImpl class 
+		 * ignore the selFlag constant and instead rely on the component's keyboard selection behavior
+		 * to handle multi-selection.The selFlag parameter may or may not contain the SELFLAG_TAKEFOCUS 
+		 * flag. If it does, you should set the child focus to the specified childID, 
+		 * and, unless SELFLAG_EXTENDSELECTION is also present, make that child element 
+		 * the selection anchor. Otherwise, the child focus and selection anchor should 
+		 * remain unmodified, despite the fact that additional flags described below 
+		 * may modify the selection.The selFlag argument will always contain one of the following four 
+		 * flags, which indicate what kind of selection modification is desired:SELFLAG_TAKESELECTION: Clear any existing selection, and set the selection 
+		 * to the specified childID.SELFLAG_EXTENDSELECTION: Calculate the range of child elements between 
+		 * and including the selection anchor and the specified childID. If 
+		 * SELFLAG_ADDSELECTION is present, add all of these child elements to the 
+		 * selection. If SELFLAG_REMOVESELECTION is present, remove all of these child 
+		 * elements from the selection. If neither SELFLAG_ADDSELECTION nor SELFLAG_REMOVESELECTION 
+		 * is present, all of these child elements should take on the selection anchor's 
+		 * selection state: if the selection anchor is selected, add these child elements 
+		 * to the selection; otherwise remove them from the selection.SELFLAG_ADDSELECTION (without SELFLAG_EXTENDSELECTION): Add the specified 
+		 * childID to the selection.SELFLAG_REMOVESELECTION (without SELFLAG_EXTENDSELECTION): Remove the 
+		 * specified childID from the selection.Note that for a non-multi-selectable component, the only valid selFlag 
+		 * parameter values are SELFLAG_TAKEFOCUS and SELFLAG_TAKESELECTION.
+		 * You could in theory 
+		 * also choose to support SELFLAG_REMOVESELECTION for a non-multi-selectable 
+		 * component that allowed the user to force a null selection, but in practice 
+		 * most non-multi-selectable components do not work this way, and MSAA clients 
+		 * may not attempt this type of operation.If you encounter flags that seem invalid, set errno to E_INVALIDARG.Finally, note that when accSelect is called, Flash Player 
+		 * ensures that it has host focus (the window focus of its container 
+		 * application), and that your component has focus within Flash Player.
+		 * @param	operation	A bitfield consisting of one or more selection flag constants to indicate
+		 *   how the item is selected or takes focus.
+		 * @param	childID	An unsigned integer corresponding to one of the component's child elements
+		 *   as defined by getChildIDArray().
+		 * @playerversion	Flash 9
+		 * @playerversion	AIR 2
+		 */
+		public function accSelect (operation:uint, childID:uint):void 
+		{
+			
+		}
+
+		/**
+		 * MSAA method for returning the default action of the component
+		 * that this AccessibilityImplementation represents or of one of its child elements.
+		 * 
+		 *   Implement this method only if the AccessibilityImplementation represents a UI element
+		 * that has a default action in the MSAA model; be sure to return the exact string 
+		 * that the MSAA model specifies.  
+		 * For example, the default action string for a Button component is "Press."If you are implementing get_accDefaultAction only for the 
+		 * AccessibilityImplementation itself, or only for its child elements, 
+		 * you will need in some cases to indicate that there is no default action 
+		 * for the particular childID that was passed. 
+		 * Do this by simply returning null.
+		 * @param	childID	An unsigned integer corresponding to one of the component's child elements,
+		 *   as defined by getChildIDArray().
+		 * @return	The default action string specified in the MSAA model for the AccessibilityImplementation
+		 *   or for one of its child elements.
+		 * @playerversion	Flash 9
+		 * @playerversion	AIR 2
+		 */
+		public function get_accDefaultAction (childID:uint):String
+		{
+			return null;
+		}
+
+		/**
+		 * MSAA method for returning the unsigned integer ID of the child element, if any, 
+		 * that has child focus within the component. If no child has child focus, the method returns zero.
+		 * @return	The unsigned integer ID of the child element, if any, that has child focus within the component.
+		 * @playerversion	Flash 9
+		 * @playerversion	AIR 2
+		 */
+		public function get_accFocus ():uint
+		{
+			return null;
+		}
+
+		/**
+		 * MSAA method for returning the name for the component
+		 * that this AccessibilityImplementation represents or for one of its child elements.
+		 * 
+		 *   In the case of the AccessibilityImplementation itself (childID == 0), 
+		 * if this method is not implemented, or does not return a value, Flash Player 
+		 * uses the AccessibilityProperties.name property value, if it is present.For AccessibilityImplementations that can have child elements, this method must be implemented,
+		 * and must return a string value when childID is nonzero.Depending on the type of user interface element, names in MSAA mean one of two different 
+		 * things: an author-assigned name, or the actual text content of the element. 
+		 * Usually, an AccessibilityImplementation itself will fall into the former category. 
+		 * Its name property is an author-assigned name. Child elements 
+		 * always fall into the second category. Their names indicate their text content.When the name property of an AccessibilityImplementation has the meaning
+		 * of an author-assigned name, there are two ways in which components can acquire names from authors.
+		 * The first entails names present within the component itself; for example, a checkbox 
+		 * component might include a text label that serves as its name. The second—a fallback from
+		 * the first—entails names specified in the UI and ending 
+		 * up in AccessibilityProperties.name. This fallback option allows users to specify 
+		 * names just as they would for any other Sprite or MovieClip.This leaves three possibilities for the AccessibilityImplementation itself (childID == zero):Author-assigned name within component. The get_accName method 
+		 * should be implemented and should return a string value that contains the 
+		 * AccessibilityImplementation's name when childID is zero. If childID is zero but the 
+		 * AccessibilityImplementation has no name, get_accName should return an empty string to prevent 
+		 * the player from falling back to the AccessibilityProperties.name property.Author-assigned name from UI. If the AccessibilityImplementation can have child 
+		 * elements, the get_accName method should be implemented but should not return a value when
+		 * childID is zero. If the AccessibilityImplementation will never have child elements, 
+		 * get_accName should not be implemented.Name signifying content. The get_accName method should be 
+		 * implemented and should return an appropriate string value when childID 
+		 * is zero. If childId is zero but the AccessibilityImplementation has no content, 
+		 * get_accName should return an empty string to prevent the player from falling back to 
+		 * the AccessibilityProperties.name property.Note that for child elements (if the AccessibilityImplementation can have them), the third case 
+		 * always applies. The get_accName method should be implemented and should 
+		 * return an appropriate string value when childID is nonzero.
+		 * @param	childID	An unsigned integer corresponding to one of the component's child elements
+		 *   as defined by getChildIDArray().
+		 * @return	Name of the component or one of its child elements.
+		 * @playerversion	Flash 9
+		 * @playerversion	AIR 2
+		 */
+		public function get_accName (childID:uint):String
+		{
+			return null;
+		}
+
+		/**
+		 * MSAA method for returning the system role for the component
+		 * that this AccessibilityImplementation represents or for one of its child elements.
+		 * System roles are predefined for all the components in MSAA.
+		 * @param	childID	An unsigned integer corresponding to one of the component's
+		 *   child elements as defined by getChildIDArray().
+		 * @return	System role associated with the component.
+		 * @playerversion	Flash 9
+		 * @playerversion	AIR 2
+		 * @throws	Error Error code 2143, AccessibilityImplementation.get_accRole() must be overridden from its default.
+		 */
+		public function get_accRole (childID:uint):uint
+		{
+			return null;
+		}
+
+		/**
+		 * MSAA method for returning an array containing the IDs of all child elements that are selected. 
+		 * The returned array may contain zero, one, or more IDs, all unsigned integers.
+		 * @return	An array of the IDs of all child elements that are selected.
+		 * @playerversion	Flash 9
+		 * @playerversion	AIR 2
+		 */
+		public function get_accSelection ():Array
+		{
+			return null;
+		}
+
+		/**
+		 * IAccessible method for returning the current runtime state of the component that this 
+		 * AccessibilityImplementation represents or of one of its child elements.
+		 * 
+		 *   This method must return a combination of zero, one, or more of the predefined
+		 * object state constants for components in MSAA. 
+		 * When more than one state applies, the state constants should be combined into a bitfield
+		 * using |, the bitwise OR operator.To indicate that none of the state constants currently applies, this method should return zero.You should not need to track or report the STATE_SYSTEM_FOCUSABLE or STATE_SYSTEM_FOCUSED states. 
+		 * Flash Player handles these states automatically.
+		 * @param	childID	An unsigned integer corresponding to one of the component's child elements
+		 *   as defined by getChildIDArray().
+		 * @return	A combination of zero, one, or more of the system state constants. 
+		 *   Multiple constants are assembled into a bitfield using |, the bitwise OR operator.
+		 * @playerversion	Flash 9
+		 * @playerversion	AIR 2
+		 * @throws	Error Error code 2144, AccessibilityImplementation.get_accState() must be overridden from its default.
+		 */
+		public function get_accState(childID:uint):uint
+		{
+			return null;
+		}
+
+		/**
+		 * MSAA method for returning the runtime value of the component that this
+		 * AccessibilityImplementation represents or of one of its child elements.
+		 * 
+		 *   Implement this method only if your AccessibilityImplementation represents a UI element
+		 * that has a value in the MSAA model. Be aware that some UI elements that have an apparent 'value' 
+		 * actually expose this value by different means, such as 
+		 * get_accName (text, for example), 
+		 * get_accState (check boxes, for example), or get_accSelection 
+		 * (list boxes, for example).If you are implementing get_accValue only for the AccessibilityImplementation itself, or 
+		 * only for its child elements, you will need in some cases to indicate that 
+		 * there is no concept of value for the particular childID that was passed. 
+		 * Do this by simply returning null.
+		 * @param	childID	An unsigned integer corresponding to one of the component's child elements
+		 *   as defined by getChildIDArray().
+		 * @return	A string representing the runtime value of the component of of one of its child elements.
+		 * @playerversion	Flash 9
+		 * @playerversion	AIR 2
+		 */
+		public function get_accValue(childID:uint):String
+		{
+			return null;
+		}
+
+		public function get_selectionActiveIndex():*
+		{
+			return null;
+		}
+
+		public function get_selectionAnchorIndex():*
+		{
+			return null;
+		}
+
+		/**
+		 * Returns an array containing the unsigned integer IDs of all child elements
+		 * in the AccessibilityImplementation.
+		 * 
+		 *   The length of the array may be zero. The IDs in the array should 
+		 * appear in the same logical order as the child elements they represent. If your 
+		 * AccessibilityImplementation can contain child elements, this method is mandatory; otherwise, do
+		 * not implement it.In assigning child IDs to your child elements, use any scheme that
+		 * preserves uniqueness within each instance of your AccessibilityImplementation. Child IDs need not 
+		 * be contiguous, and their ordering need not match the logical ordering of the 
+		 * child elements. You should arrange so as to not reuse child IDs; if a child 
+		 * element is deleted, its ID should never be used again for the lifetime of 
+		 * that AccessibilityImplementation instance. Be aware that, due to implementation choices in the Flash 
+		 * player code, undesirable behavior can result if you use child IDs that exceed 
+		 * one million.
+		 * @return	Array containing the unsigned integer IDs of all child elements in the AccessibilityImplementation.
+		 * @playerversion	Flash 9
+		 * @playerversion	AIR 2
+		 */
+		public function getChildIDArray():Array
+		{
+			return null;
+		}
+
+		/**
+		 * Returns true or false to indicate whether a text object having 
+		 * a bounding box specified by a x, y, width, and height 
+		 * should be considered a label for the component that this AccessibilityImplementation represents.
+		 * 
+		 *   The x and y coordinates are relative to the upper-left corner 
+		 * of the component to which the AccessibilityImplementation applies, and may be negative. All coordinates 
+		 * are in units of Stage pixels.This method allows accessible components to fit into the Flash Player's search 
+		 * for automatic labeling relationships, which allow text external to an object 
+		 * to supply the object's name. This method is provided because it is expected 
+		 * that the criteria for recognizing labels will differ from component to component. 
+		 * If you implement this method, you should aim to use geometric criteria similar 
+		 * to those in use inside the player code for buttons and textfields. Those criteria
+		 * are as follows:For buttons, any text falling entirely inside the button is considered a label.For textfields, any text appearing nearby above and left-aligned, 
+		 * or nearby to the left, is considered a label.If the component that the AccessibilityImplementation represents should never participate in automatic 
+		 * labeling relationships, do not implement isLabeledBy. This is equivalent 
+		 * to always returning false. One case in which isLabeledBy should 
+		 * not be implemented is when the AccessibilityImplementation falls into the "author-assigned name 
+		 * within component" case described under get_accName above.Note that this method is not based on any IAccessible method; it is 
+		 * specific to Flash.
+		 * @param	labelBounds	A Rectangle representing the bounding box of a text object.
+		 * @return	true or false to indicate whether a text object having the given label bounds should be considered a label for the component that this AccessibilityImplementation represents.
+		 * @playerversion	Flash 9
+		 * @playerversion	AIR 2
+		 */
+		public function isLabeledBy (labelBounds:Rectangle):Boolean
+		{
+			return null;
+		}
+	}
+}

--- a/src/flash/accessibility/AccessibilityProperties.as
+++ b/src/flash/accessibility/AccessibilityProperties.as
@@ -1,0 +1,264 @@
+//
+// F:\flexjssdk\frameworks\libs\player\22.0\playerglobal.swc\flash\accessibility\AccessibilityProperties
+//
+package flash.accessibility
+{
+	/**
+	 * The AccessibilityProperties class lets you control the presentation of Flash objects to accessibility
+	 * aids, such as screen readers.
+	 * 
+	 *   <p class="- topic/p ">You can attach an AccessibilityProperties object to any display object, but Flash Player will read
+	 * your AccessibilityProperties object only for certain kinds of objects: entire
+	 * SWF files (as represented by <codeph class="+ topic/ph pr-d/codeph ">DisplayObject.root</codeph>), container objects
+	 * (<codeph class="+ topic/ph pr-d/codeph ">DisplayObjectContainer</codeph> and subclasses), buttons
+	 * (<codeph class="+ topic/ph pr-d/codeph ">SimpleButton</codeph> and subclasses), and text (<codeph class="+ topic/ph pr-d/codeph ">TextField</codeph> and subclasses).</p><p class="- topic/p ">The <codeph class="+ topic/ph pr-d/codeph ">name</codeph> property of these objects is the most important property to specify because
+	 * accessibility aids provide the names of objects to users as a basic means of navigation.  Do not
+	 * confuse <codeph class="+ topic/ph pr-d/codeph ">AccessibilityProperties.name</codeph> with <codeph class="+ topic/ph pr-d/codeph ">DisplayObject.name</codeph>; these are
+	 * separate and unrelated.  The <codeph class="+ topic/ph pr-d/codeph ">AccessibilityProperties.name</codeph> property is a name 
+	 * that is read aloud by the accessibility aids, whereas <codeph class="+ topic/ph pr-d/codeph ">DisplayObject.name</codeph> is essentially a
+	 * variable name visible only to ActionScript code.</p><p class="- topic/p ">In Flash Professional, the properties of <codeph class="+ topic/ph pr-d/codeph ">AccessibilityProperties</codeph> objects override
+	 * the corresponding settings available in the Accessibility panel during authoring.</p><p class="- topic/p ">To determine whether Flash Player is running in an environment that supports accessibility aids, use 
+	 * the <codeph class="+ topic/ph pr-d/codeph ">Capabilities.hasAccessibility</codeph> property.  If you modify AccessibilityProperties
+	 * objects, you need to call the <codeph class="+ topic/ph pr-d/codeph ">Accessibility.updateProperties()</codeph> method for the changes to
+	 * take effect.</p>
+	 * 
+	 *   EXAMPLE:
+	 * 
+	 *   The following example uses the <codeph class="+ topic/ph pr-d/codeph ">AccessibilityExample</codeph>,
+	 * <codeph class="+ topic/ph pr-d/codeph ">CustomAccessibleButton</codeph>, <codeph class="+ topic/ph pr-d/codeph ">CustomSimpleButton</codeph>, and <codeph class="+ topic/ph pr-d/codeph ">ButtonDisplayState</codeph> classes
+	 * to create an accessibility-compliant menu that works with common screen readers. The main
+	 * functionality of the <codeph class="+ topic/ph pr-d/codeph ">AccessibilityProperties</codeph> class is as follows:
+	 * 
+	 *   <ol TYPE="1" class="- topic/ol "><li class="- topic/li "> Call <codeph class="+ topic/ph pr-d/codeph ">configureAssets</codeph>, which creates a custom button and sets its label and 
+	 * description. These are the values that the screen reader conveys to the end user.</li><li class="- topic/li ">Call <codeph class="+ topic/ph pr-d/codeph ">setTimeOut()</codeph> to ensure that Flash Player has enough time to detect the 
+	 * screen reader before updating the properties.</li></ol><p class="- topic/p "><b class="+ topic/ph hi-d/b ">Note:</b> Call <codeph class="+ topic/ph pr-d/codeph ">setTimeout()</codeph> before checking <codeph class="+ topic/ph pr-d/codeph ">Accessibility.active</codeph>.
+	 * to give Flash Player the 2 seconds it needs to connect to a screen reader,
+	 * if one is available. If you do not provide a sufficient delay time, the <codeph class="+ topic/ph pr-d/codeph ">setTimeout</codeph> call might return <codeph class="+ topic/ph pr-d/codeph ">false</codeph>, even
+	 * if a screen reader is available.</p><p class="- topic/p ">The following example processes the <codeph class="+ topic/ph pr-d/codeph ">Accessibility.updateProperties()</codeph>
+	 * method only if the call to <codeph class="+ topic/ph pr-d/codeph ">Accessibility.active</codeph> returns <codeph class="+ topic/ph pr-d/codeph ">true</codeph>, which 
+	 * occurs only if Flash Player is currently connected to an active screen reader. If <codeph class="+ topic/ph pr-d/codeph ">updateProperties</codeph>
+	 * is called without an active screen reader, it throws an <codeph class="+ topic/ph pr-d/codeph ">IllegalOperationError</codeph> exception.</p><codeblock xml:space="preserve" class="+ topic/pre pr-d/codeblock ">
+	 * package {
+	 * import flash.display.Sprite;
+	 * import flash.accessibility.Accessibility;
+	 * import flash.utils.setTimeout;
+	 * 
+	 *   public class AccessibilityPropertiesExample extends Sprite {
+	 * public static const BUTTON_WIDTH:uint = 90;
+	 * public static const BUTTON_HEIGHT:uint = 20;
+	 * 
+	 *   private var gutter:uint = 5;
+	 * private var menuLabels:Array = new Array("PROJECTS", "PORTFOLIO", "CONTACT");
+	 * private var menuDescriptions:Array = new Array("Learn more about our projects"
+	 * , "See our portfolio"
+	 * , "Get in touch with our team");
+	 * 
+	 *   public function AccessibilityPropertiesExample() {
+	 * configureAssets();
+	 * setTimeout(updateAccessibility, 2000); 
+	 * }
+	 * 
+	 *   private function updateAccessibility():void {
+	 * trace("Accessibility.active: " + Accessibility.active);
+	 * if(Accessibility.active) {
+	 * Accessibility.updateProperties();
+	 * }
+	 * }
+	 * 
+	 *   private function configureAssets():void {
+	 * var child:CustomAccessibleButton;
+	 * for(var i:uint; i &lt; menuLabels.length; i++) {
+	 * child = new CustomAccessibleButton();
+	 * child.y = (numChildren * (BUTTON_HEIGHT + gutter));
+	 * child.setLabel(menuLabels[i]);
+	 * child.setDescription(menuDescriptions[i]);
+	 * addChild(child);
+	 * }
+	 * }
+	 * }
+	 * 
+	 *   import flash.accessibility.AccessibilityProperties;
+	 * import flash.display.Shape;
+	 * import flash.display.SimpleButton;
+	 * import flash.display.Sprite;
+	 * import flash.events.Event;
+	 * import flash.text.TextFormat;
+	 * import flash.text.TextField;
+	 * 
+	 *   class CustomAccessibleButton extends Sprite {
+	 * private var button:SimpleButton;
+	 * private var label1:TextField;
+	 * private var description:String;
+	 * private var _name:String;
+	 * 
+	 *   public function CustomAccessibleButton(_width:uint = 0, _height:uint = 0) {
+	 * _width = (_width == 0) ? AccessibilityPropertiesExample.BUTTON_WIDTH:_width;
+	 * _height = (_height == 0) ? AccessibilityPropertiesExample.BUTTON_HEIGHT:_height;
+	 * 
+	 *   button = buildButton(_width, _height);
+	 * label1 = buildLabel(_width, _height);
+	 * 
+	 *   addEventListener(Event.ADDED, addedHandler);
+	 * }
+	 * 
+	 *   private function addedHandler(event:Event):void {
+	 * trace("addedHandler: " + name);
+	 * var accessProps:AccessibilityProperties = new AccessibilityProperties();
+	 * accessProps.name = this._name;
+	 * accessProps.description = description;
+	 * accessibilityProperties = accessProps;
+	 * removeEventListener(Event.ADDED, addedHandler);
+	 * }
+	 * 
+	 *   private function buildButton(_width:uint, _height:uint):SimpleButton {
+	 * var child:SimpleButton = new CustomSimpleButton(_width, _height);
+	 * addChild(child);
+	 * return child;
+	 * }
+	 * 
+	 *   private function buildLabel(_width:uint, _height:uint):TextField {
+	 * var format:TextFormat = new TextFormat();
+	 * format.font = "Verdana";
+	 * format.size = 11;
+	 * format.color = 0xFFFFFF;
+	 * format.align = TextFormatAlign.CENTER;
+	 * format.bold = true;
+	 * 
+	 *   var child:TextField = new TextField();
+	 * child.y = 1;
+	 * child.width = _width;
+	 * child.height = _height;
+	 * child.selectable = false;
+	 * child.defaultTextFormat = format;
+	 * child.mouseEnabled = false;
+	 * 
+	 *   addChild(child);
+	 * return child;
+	 * }
+	 * 
+	 *   public function setLabel(text:String):void {
+	 * label1.text = text;
+	 * this._name = text;
+	 * }
+	 * 
+	 *   public function setDescription(text:String):void {
+	 * description = text;
+	 * }
+	 * }
+	 * 
+	 *   class CustomSimpleButton extends SimpleButton {
+	 * private var upColor:uint = 0xFFCC00;
+	 * private var overColor:uint = 0xCCFF00;
+	 * private var downColor:uint = 0x00CCFF;
+	 * 
+	 *   public function CustomSimpleButton(_width:uint, _height:uint) {
+	 * downState = new ButtonDisplayState(downColor, _width, _height);
+	 * overState = new ButtonDisplayState(overColor, _width, _height);
+	 * upState = new ButtonDisplayState(upColor, _width, _height);
+	 * hitTestState = new ButtonDisplayState(upColor, _width, _height);
+	 * useHandCursor = true;
+	 * }        
+	 * }
+	 * 
+	 *   class ButtonDisplayState extends Shape {
+	 * private var bgColor:uint;
+	 * private var _width:uint;
+	 * private var _height:uint;
+	 * 
+	 *   public function ButtonDisplayState(bgColor:uint, _width:uint, _height:uint) {
+	 * this.bgColor = bgColor;
+	 * this._width = _width;
+	 * this._height = _height;
+	 * draw();
+	 * }
+	 * 
+	 *   private function draw():void {
+	 * graphics.beginFill(bgColor);
+	 * graphics.drawRect(0, 0, _width, _height);
+	 * graphics.endFill();
+	 * }
+	 * }
+	 * }
+	 * </codeblock>
+	 * @langversion	3.0
+	 * @playerversion	Flash 9
+	 */
+	public class AccessibilityProperties extends Object
+	{
+		/**
+		 * Provides a description for this display object in the accessible presentation.
+		 * If you have a lot of information to present about the object, it is
+		 * best to choose a concise name and put most of your content in the
+		 * description property. 
+		 * Applies to whole SWF files, containers, buttons, and text. The default value
+		 * is an empty string.
+		 * In Flash Professional, this property corresponds to the Description field in the Accessibility panel.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 */
+		public var description:String;
+
+		/**
+		 * If true, causes Flash Player to exclude child objects within this
+		 * display object from the accessible presentation.  
+		 * The default is false. Applies to whole SWF files and containers.
+		 * @playerversion	Flash 9
+		 */
+		public var forceSimple:Boolean;
+
+		/**
+		 * Provides a name for this display object in the accessible presentation. 
+		 * Applies to whole SWF files, containers, buttons, and text.  Do not confuse with
+		 * DisplayObject.name, which is unrelated. The default value
+		 * is an empty string.
+		 * In Flash Professional, this property corresponds to the Name field in the Accessibility panel.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 */
+		public var name:String;
+
+		/**
+		 * If true, disables the Flash Player default auto-labeling system.
+		 * Auto-labeling causes text objects inside buttons to be treated as button names,
+		 * and text objects near text fields to be treated as text field names.
+		 * The default is false. Applies only to whole SWF files.
+		 * The noAutoLabeling property value is ignored unless you specify it before the
+		 * first time an accessibility aid examines your SWF file. If you plan to set 
+		 * noAutoLabeling to true, you should do so as early as 
+		 * possible in your code.
+		 * @playerversion	Flash 9
+		 */
+		public var noAutoLabeling:Boolean;
+
+		/**
+		 * Indicates a keyboard shortcut associated with this display object. 
+		 * Supply this string only for UI controls that you have associated with a shortcut key. 
+		 * Applies to containers, buttons, and text.  The default value
+		 * is an empty string.
+		 * 
+		 *   Note: Assigning this property does not automatically assign the specified key
+		 * combination to this object; you must do that yourself, for example, by
+		 * listening for a KeyboardEvent.The syntax for this string uses long names for modifier keys, and
+		 * the plus(+) character to indicate key combination. Examples of valid strings are
+		 * "Ctrl+F", "Ctrl+Shift+Z", and so on.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 */
+		public var shortcut:String;
+
+		/**
+		 * If true, excludes this display object from accessible presentation.
+		 * The default is false. Applies to whole SWF files, containers, buttons, and text.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 */
+		public var silent:Boolean;
+
+		/**
+		 * Creates a new AccessibilityProperties object.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 */
+		public function AccessibilityProperties();
+	}
+}

--- a/src/flash/display/DisplayObject.as
+++ b/src/flash/display/DisplayObject.as
@@ -16,10 +16,13 @@ package flash.display
 	 */
 	public class DisplayObject extends EventDispatcher implements IBitmapDrawable
 	{
+		private static var _globalStage:Stage;
+		private var _stage:Stage;
+		private var _inited:Boolean = false;
+		
 		private static var ID:int = 0;
 		public var innerID:int;
 		private var _name:String;
-		protected var _stage:Stage;
 		private var _rotation:Number = 0;
 		private var rsin:Number = 0;
 		private var rcos:Number = 1;
@@ -28,23 +31,41 @@ package flash.display
 		private var _visible:Boolean = true;
 		private var lastMouseOverObj:DisplayObject;
 		private var _blendMode:String;
+		
 		public function DisplayObject()
 		{
-			_blendMode = BlendMode.NORMAL;
-			transform = new Transform(this);
-			innerID = ID++;
-			name = "instance" + innerID;
-			if (innerID === 0)
+			_stage = _globalStage;
+			
+			if (_stage) init();
+		}
+		
+		public function init():void
+		{
+			if (!_inited)
 			{
-				_stage = new Stage;
-				_stage.addEventListener(Event.ENTER_FRAME, __enterFrame);
-				_stage.addEventListener(MouseEvent.CLICK, __mouseevent);
-				_stage.addEventListener(MouseEvent.CONTEXT_MENU, __mouseevent);
-				_stage.addEventListener(MouseEvent.DOUBLE_CLICK, __mouseevent);
-				_stage.addEventListener(MouseEvent.MOUSE_DOWN, __mouseevent);
-				_stage.addEventListener(MouseEvent.MOUSE_MOVE, __mouseevent);
-				_stage.addEventListener(MouseEvent.MOUSE_UP, __mouseevent);
+				_blendMode = BlendMode.NORMAL;
+				transform = new Transform(this);
+				innerID = ID++;
+				name = "instance" + innerID;
+				
+				if (innerID === 0)
+				{
+					_stage = _globalStage;
+					_stage.addEventListener(Event.ENTER_FRAME, __enterFrame);
+					_stage.addEventListener(MouseEvent.CLICK, __mouseevent);
+					_stage.addEventListener(MouseEvent.CONTEXT_MENU, __mouseevent);
+					_stage.addEventListener(MouseEvent.DOUBLE_CLICK, __mouseevent);
+					_stage.addEventListener(MouseEvent.MOUSE_DOWN, __mouseevent);
+					_stage.addEventListener(MouseEvent.MOUSE_MOVE, __mouseevent);
+					_stage.addEventListener(MouseEvent.MOUSE_UP, __mouseevent);
+				}
+				_inited = true;
 			}
+		}
+		
+		public static function set initStage(value:Stage):void 
+		{
+			_globalStage = value;
 		}
 		
 		public function get stage():Stage  { return _stage; }
@@ -55,6 +76,7 @@ package flash.display
 				if (_stage) {
 					dispatchEvent(new Event(Event.ADDED_TO_STAGE));
 				}else {
+					SpriteFlexjs.dirtyGraphics = true;
 					dispatchEvent(new Event(Event.REMOVED_FROM_STAGE));
 				}
 			}

--- a/src/flash/display/DisplayObjectContainer.as
+++ b/src/flash/display/DisplayObjectContainer.as
@@ -9,9 +9,11 @@ package flash.display
 	{
 		private var children:Array = [];
 		private var _mouseChildren:Boolean = true;
+		
 		public function DisplayObjectContainer()
 		{
 			super();
+			
 		}
 		
 		public function addChild(child:DisplayObject):DisplayObject
@@ -74,7 +76,7 @@ package flash.display
 		
 		public function get numChildren():int  { return children.length; }
 		
-		override public function get stage():Stage 
+		/*override public function get stage():Stage 
 		{
 			return _stage;
 		}
@@ -94,7 +96,7 @@ package flash.display
 				var c:DisplayObject = children[i];
 				c.stage = v;
 			}
-		}
+		}*/
 		
 		
 		//flexjs 编译变慢bug，等sdk改正后再改回来

--- a/src/flash/display/IBitmapDrawable.as
+++ b/src/flash/display/IBitmapDrawable.as
@@ -2,5 +2,6 @@ package flash.display
 {
    public interface IBitmapDrawable
    {
-       }
+       
+   }
 }

--- a/src/flash/display/IStage.as
+++ b/src/flash/display/IStage.as
@@ -1,0 +1,23 @@
+package flash.display 
+{
+	public interface IStage 
+	{
+		function addEventListener(type:String, listener:Function, useCapture:Boolean=false, priority:int=0, useWeakReference:Boolean = false):void; 
+		function removeEventListener(type:String, listener:Function, useCapture:Boolean=false):void; 
+		//function dispatchEvent(event:Event):Boolean; 
+		function hasEventListener(type:String):Boolean; 
+		function willTrigger(type:String):Boolean;
+		
+		function set x(value:Number):void;
+		function set y(value:Number):void;
+		function set z(value:Number):void;
+		
+		function get mouseX():Number;
+		function get mouseY():Number;
+		function get stageWidth():int;
+		function get stageHeight():int;
+		
+		function get ctx():CanvasRenderingContext2D;
+	}
+
+}

--- a/src/flash/display/MovieClip.as
+++ b/src/flash/display/MovieClip.as
@@ -1,0 +1,334 @@
+package flash.display
+{
+	import flash.display.Scene;
+
+	/**
+	 * The MovieClip class inherits from the following classes: Sprite, DisplayObjectContainer, 
+	 * InteractiveObject, DisplayObject, and EventDispatcher.
+	 * 
+	 *   <p class="- topic/p ">Unlike the Sprite object, a MovieClip object has a timeline.</p><p class="- topic/p ">&gt;In Flash Professional, the methods for the MovieClip class provide the same functionality 
+	 * as actions that target movie clips. Some additional methods do not have equivalent 
+	 * actions in the Actions toolbox in the Actions panel in the Flash authoring tool. </p><p class="- topic/p ">Children instances placed on the Stage in Flash Professional cannot be accessed by code from within the
+	 * constructor of a parent instance since they have not been created at that point in code execution.
+	 * Before accessing the child, the parent must instead either create the child instance
+	 * by code or delay access to a callback function that listens for the child to dispatch
+	 * its <codeph class="+ topic/ph pr-d/codeph ">Event.ADDED_TO_STAGE</codeph> event.</p><p class="- topic/p ">If you modify any of the following properties of a MovieClip object that contains a motion tween,
+	 * the playhead is stopped in that MovieClip object: <codeph class="+ topic/ph pr-d/codeph ">alpha</codeph>, <codeph class="+ topic/ph pr-d/codeph ">blendMode</codeph>, 
+	 * <codeph class="+ topic/ph pr-d/codeph ">filters</codeph>, <codeph class="+ topic/ph pr-d/codeph ">height</codeph>, <codeph class="+ topic/ph pr-d/codeph ">opaqueBackground</codeph>, <codeph class="+ topic/ph pr-d/codeph ">rotation</codeph>, 
+	 * <codeph class="+ topic/ph pr-d/codeph ">scaleX</codeph>, <codeph class="+ topic/ph pr-d/codeph ">scaleY</codeph>, <codeph class="+ topic/ph pr-d/codeph ">scale9Grid</codeph>, <codeph class="+ topic/ph pr-d/codeph ">scrollRect</codeph>, 
+	 * <codeph class="+ topic/ph pr-d/codeph ">transform</codeph>, <codeph class="+ topic/ph pr-d/codeph ">visible</codeph>, <codeph class="+ topic/ph pr-d/codeph ">width</codeph>, <codeph class="+ topic/ph pr-d/codeph ">x</codeph>, 
+	 * or <codeph class="+ topic/ph pr-d/codeph ">y</codeph>. However, it does not stop the playhead in any child MovieClip objects of that 
+	 * MovieClip object.</p><p class="- topic/p "><b class="+ topic/ph hi-d/b ">Note:</b>Flash Lite 4 supports the MovieClip.opaqueBackground property only if 
+	 * FEATURE_BITMAPCACHE is defined. The default configuration of Flash Lite 4 does not define 
+	 * FEATURE_BITMAPCACHE. To enable the MovieClip.opaqueBackground property for a suitable device, 
+	 * define FEATURE_BITMAPCACHE in your project.</p>
+	 * 
+	 *   EXAMPLE:
+	 * 
+	 *   The following example uses the MovieClipExample class to illustrate how
+	 * to monitor various properties of a MovieClip.  This task is accomplished by performing the following steps:
+	 * 
+	 *   <ol class="- topic/ol "><li class="- topic/li ">The constructor function defines a text field, which is used to display values of properties
+	 * of the MovieClipExample object (which extends MovieClip).</li><li class="- topic/li ">The return value of the <codeph class="+ topic/ph pr-d/codeph ">getPropertiesString()</codeph> method is used as text for the 
+	 * <codeph class="+ topic/ph pr-d/codeph ">outputText</codeph> text field. The <codeph class="+ topic/ph pr-d/codeph ">getPropertiesString()</codeph> method returns
+	 * a string that is populated with values of the following properties of the movie clip: 
+	 * <codeph class="+ topic/ph pr-d/codeph ">currentFrame</codeph>, <codeph class="+ topic/ph pr-d/codeph ">currentLabel</codeph>, <codeph class="+ topic/ph pr-d/codeph ">currentScene</codeph>, 
+	 * <codeph class="+ topic/ph pr-d/codeph ">framesLoaded</codeph>, <codeph class="+ topic/ph pr-d/codeph ">totalFrames</codeph>, and <codeph class="+ topic/ph pr-d/codeph ">trackAsMenu</codeph>.</li><li class="- topic/li ">Two lines of code in the constructor function adjust the <codeph class="+ topic/ph pr-d/codeph ">width</codeph> and
+	 * <codeph class="+ topic/ph pr-d/codeph ">height</codeph> properties of the <codeph class="+ topic/ph pr-d/codeph ">outputText</codeph> text field.</li><li class="- topic/li ">The last line of the constructor function adds the <codeph class="+ topic/ph pr-d/codeph ">outputText</codeph> text field
+	 * to the display list.</li></ol><codeblock xml:space="preserve" class="+ topic/pre pr-d/codeblock ">
+	 * 
+	 *   package {
+	 * import flash.display.MovieClip;
+	 * import flash.text.TextField;
+	 * 
+	 *   public class MovieClipExample extends MovieClip {
+	 * 
+	 *   public function MovieClipExample() {
+	 * var outputText:TextField = new TextField();
+	 * outputText.text = getPropertiesString();
+	 * outputText.width = stage.stageWidth;
+	 * outputText.height = outputText.textHeight;
+	 * addChild(outputText);
+	 * }
+	 * 
+	 *   private function getPropertiesString():String {
+	 * var str:String = ""
+	 * + "currentFrame: " + currentFrame + "\n"
+	 * + "currentLabel: " + currentLabel + "\n"
+	 * + "currentScene: " + currentScene + "\n"
+	 * + "framesLoaded: " + framesLoaded + "\n"
+	 * + "totalFrames: " + totalFrames + "\n"
+	 * + "trackAsMenu: " + trackAsMenu + "\n";
+	 * return str;
+	 * }
+	 * }
+	 * }
+	 * </codeblock>
+	 * @langversion	3.0
+	 * @playerversion	Flash 9
+	 * @playerversion	Lite 4
+	 */
+	public dynamic class MovieClip extends Sprite
+	{
+		private var _currentFrame:int = 1;
+		private var _currentFrameLabel:String = "";
+		private var _currentLabel:String = "";
+		private var _currentLabels:Array = [];
+		private var _currentScene:Scene;
+		private var _enabled:Boolean = true;
+		private var _framesLoaded:int = 1;
+		private var _isPlaying:Boolean = false;
+		private var _scenes:Array = [];
+		private var _totalFrames:int = 1;
+		private var _trackAsMenu:Boolean = false;
+		
+		/**
+		 * Specifies the number of the frame in which the playhead is located in the timeline of 
+		 * the MovieClip instance. If the movie clip has multiple scenes, this value is the 
+		 * frame number in the current scene.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 */
+		public function get currentFrame():int { return _currentFrame; }
+
+		/**
+		 * The label at the current frame in the timeline of the MovieClip instance.
+		 * If the current frame has no label, currentLabel is null.
+		 * @langversion	3.0
+		 * @playerversion	Flash 10
+		 * @playerversion	AIR 1.5
+		 * @playerversion	Lite 4
+		 */
+		public function get currentFrameLabel():String { return _currentFrameLabel; }
+
+		/**
+		 * The current label in which the playhead is located in the timeline of the MovieClip instance.
+		 * If the current frame has no label, currentLabel is set to the name of the previous frame 
+		 * that includes a label. If the current frame and previous frames do not include a label,
+		 * currentLabel returns null.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 */
+		public function get currentLabel():String { return _currentLabel; }
+
+		/**
+		 * Returns an array of FrameLabel objects from the current scene. If the MovieClip instance does
+		 * not use scenes, the array includes all frame labels from the entire MovieClip instance.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 */
+		public function get currentLabels():Array { return _currentLabels; }
+
+		/**
+		 * The current scene in which the playhead is located in the timeline of the MovieClip instance.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 */
+		public function get currentScene():Scene { return _currentScene; }
+
+		/**
+		 * A Boolean value that indicates whether a movie clip is enabled. The default value of enabled
+		 * is true. If enabled is set to false, the movie clip's
+		 * Over, Down, and Up frames are disabled. The movie clip
+		 * continues to receive events (for example, mouseDown,
+		 * mouseUp, keyDown, and keyUp).
+		 * 
+		 *   The enabled property governs only the button-like properties of a movie clip. You
+		 * can change the enabled property at any time; the modified movie clip is immediately
+		 * enabled or disabled. If enabled is set to false, the object is not 
+		 * included in automatic tab ordering.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 */
+		public function get enabled():Boolean { return _enabled; }
+		public function set enabled (value:Boolean):void
+		{
+			
+		}
+
+		/**
+		 * The number of frames that are loaded from a streaming SWF file. You can use the framesLoaded 
+		 * property to determine whether the contents of a specific frame and all the frames before it
+		 * loaded and are available locally in the browser. You can also use it to monitor the downloading 
+		 * of large SWF files. For example, you might want to display a message to users indicating that 
+		 * the SWF file is loading until a specified frame in the SWF file finishes loading.
+		 * 
+		 *   If the movie clip contains multiple scenes, the framesLoaded property returns the number 
+		 * of frames loaded for all scenes in the movie clip.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 */
+		public function get framesLoaded():int { return _framesLoaded; }
+
+		public function get isPlaying():Boolean { return _isPlaying; }
+
+		/**
+		 * An array of Scene objects, each listing the name, the number of frames,
+		 * and the frame labels for a scene in the MovieClip instance.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 */
+		public function get scenes():Array { return _scenes; }
+
+		/**
+		 * The total number of frames in the MovieClip instance.
+		 * 
+		 *   If the movie clip contains multiple frames, the totalFrames property returns 
+		 * the total number of frames in all scenes in the movie clip.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 */
+		public function get totalFrames():int { return _totalFrames; }
+
+		/**
+		 * Indicates whether other display objects that are SimpleButton or MovieClip objects can receive 
+		 * mouse release events or other user input release events. The trackAsMenu property lets you create menus. You 
+		 * can set the trackAsMenu property on any SimpleButton or MovieClip object.
+		 * The default value of the trackAsMenu property is false.
+		 * 
+		 *   You can change the trackAsMenu property at any time; the modified movie 
+		 * clip immediately uses the new behavior.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 */
+		public function get trackAsMenu():Boolean { return _trackAsMenu; }
+		public function set trackAsMenu (value:Boolean):void
+		{
+			
+		}
+
+		public function addFrameScript (...rest):void
+		{
+			
+		}
+
+		/**
+		 * Starts playing the SWF file at the specified frame.  This happens after all 
+		 * remaining actions in the frame have finished executing.  To specify a scene 
+		 * as well as a frame, specify a value for the scene parameter.
+		 * @param	frame	A number representing the frame number, or a string representing the label of the 
+		 *   frame, to which the playhead is sent. If you specify a number, it is relative to the 
+		 *   scene you specify. If you do not specify a scene, the current scene determines the global frame number to play. If you do specify a scene, the playhead
+		 *   jumps to the frame number in the specified scene.
+		 * @param	scene	The name of the scene to play. This parameter is optional.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 */
+		public function gotoAndPlay (frame:Object, scene:String = null):void
+		{
+			
+		}
+
+		/**
+		 * Brings the playhead to the specified frame of the movie clip and stops it there.  This happens after all 
+		 * remaining actions in the frame have finished executing.  If you want to specify a scene in addition to a frame, 
+		 * specify a scene parameter.
+		 * @param	frame	A number representing the frame number, or a string representing the label of the 
+		 *   frame, to which the playhead is sent. If you specify a number, it is relative to the 
+		 *   scene you specify. If you do not specify a scene, the current scene determines the global frame number at which to go to and stop. If you do specify a scene, 
+		 *   the playhead goes to the frame number in the specified scene and stops.
+		 * @param	scene	The name of the scene. This parameter is optional.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 * @throws	ArgumentError If the scene or frame specified are
+		 *   not found in this movie clip.
+		 */
+		public function gotoAndStop (frame:Object, scene:String = null):void
+		{
+			
+		}
+
+		/**
+		 * Creates a new MovieClip instance. After creating the MovieClip, call the 
+		 * addChild() or addChildAt() method of a
+		 * display object container that is onstage.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 */
+		public function MovieClip()
+		{
+			super();
+		}
+
+		/**
+		 * Sends the playhead to the next frame and stops it.  This happens after all 
+		 * remaining actions in the frame have finished executing.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 */
+		public function nextFrame():void
+		{
+			
+		}
+
+		/**
+		 * Moves the playhead to the next scene of the MovieClip instance.  This happens after all 
+		 * remaining actions in the frame have finished executing.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 */
+		public function nextScene():void
+		{
+			
+		}
+
+		/**
+		 * Moves the playhead in the timeline of the movie clip.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 */
+		public function play():void
+		{
+			
+		}
+
+		/**
+		 * Sends the playhead to the previous frame and stops it.  This happens after all 
+		 * remaining actions in the frame have finished executing.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 */
+		public function prevFrame():void
+		{
+			
+		}
+
+		/**
+		 * Moves the playhead to the previous scene of the MovieClip instance.  This happens after all 
+		 * remaining actions in the frame have finished executing.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 */
+		public function prevScene():void
+		{
+			
+		}
+
+		/**
+		 * Stops the playhead in the movie clip.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 */
+		public function stop():void
+		{
+			
+		}
+	}
+}

--- a/src/flash/display/NativeMenu.as
+++ b/src/flash/display/NativeMenu.as
@@ -1,0 +1,82 @@
+package flash.display
+{
+	import flash.events.EventDispatcher;
+
+	/**
+	 * Dispatched by the NativeMenu object when a key equivalent is pressed and immediately before the menu is displayed.
+	 * @eventType	flash.events.Event.PREPARING
+	 */
+	[Event(name="preparing", type="flash.events.Event")] 
+
+	/**
+	 * Dispatched by this NativeMenu object immediately before the 
+	 * menu is displayed.
+	 * @eventType	flash.events.Event.DISPLAYING
+	 */
+	[Event(name="displaying", type="flash.events.Event")] 
+
+	/**
+	 * Dispatched by this NativeMenu object when one of its menu items or an item 
+	 * in one of its descendant submenus is selected.
+	 * @eventType	flash.events.Event.SELECT
+	 */
+	[Event(name="select", type="flash.events.Event")] 
+
+	/**
+	 * The NativeMenu class contains methods and properties for defining native menus.
+	 * 
+	 *   <p class="- topic/p "><i class="+ topic/ph hi-d/i ">AIR profile support:</i> This feature is supported 
+	 * on all desktop operating systems, but is not supported on mobile devices or AIR for TV devices. You can test 
+	 * for support at run time using the <codeph class="+ topic/ph pr-d/codeph ">NativeMenu.isSupported</codeph> property. See 
+	 * <xref href="http://help.adobe.com/en_US/air/build/WS144092a96ffef7cc16ddeea2126bb46b82f-8000.html" class="- topic/xref ">
+	 * AIR Profile Support</xref> for more information regarding API support across multiple profiles.</p><p class="- topic/p ">A native menu is a menu that is controlled and drawn by the operating system rather than by your application. 
+	 * AIR supports the following types of native menus:</p><ul class="- topic/ul "><li class="- topic/li "><b class="+ topic/ph hi-d/b ">Application menus</b> are supported on OS X. Use the <codeph class="+ topic/ph pr-d/codeph ">NativeApplication.supportsMenu</codeph> property to test whether 
+	 * application menus are supported on the host operating system. An application menu is displayed on the Menu bar at the top of the 
+	 * Mac desktop. OS X provides a default menu for every application, but many of the menu commands are not functional. You can add
+	 * event listeners to the default items, replace individual menus and items, or even replace the default menu entirely.
+	 * Access the application menu object using the NativeApplication <codeph class="+ topic/ph pr-d/codeph ">menu</codeph> property.</li><li class="- topic/li "><b class="+ topic/ph hi-d/b ">Window menus</b> are supported on Windows and Linux. Use the <codeph class="+ topic/ph pr-d/codeph ">NativeWindow.supportsMenu</codeph> property to
+	 * test whether window menus are supported on the host operating system. A window menu is displayed below the window title bar. The area
+	 * occupied by the menu is not part of the window stage. Applications cannot draw into this area. Assign a menu to a window using the 
+	 * NativeWindow <codeph class="+ topic/ph pr-d/codeph ">menu</codeph> property.</li><li class="- topic/li "><b class="+ topic/ph hi-d/b ">Dock icon menus</b> are supported on OS X. Use the <codeph class="+ topic/ph pr-d/codeph ">NativeApplication.supportsDockIcon</codeph> property to test whether
+	 * dock icons are supported on the host operating system. Items in a dock icon menu are displayed above the default items provided by
+	 * the operating system. The default items cannot be accessed by application code. Assign a menu to the <codeph class="+ topic/ph pr-d/codeph ">menu</codeph> property of
+	 * the application's DockIcon object.</li><li class="- topic/li "><b class="+ topic/ph hi-d/b ">System tray icon menus</b> are supported on Windows and most Linux operating systems. Use the 
+	 * <codeph class="+ topic/ph pr-d/codeph ">NativeApplication.supportsSystemTrayIcon</codeph> property to test whether system tray icons are supported on the host
+	 * operating system. A system tray icon menu is displayed in response to a right-click on the icon, in much the same fashion as
+	 * a context menu. Assign a menu to the <codeph class="+ topic/ph pr-d/codeph ">menu</codeph> property of the application's SystemTrayIcon object.</li><li class="- topic/li "><b class="+ topic/ph hi-d/b ">Context menus</b> are supported on all operating systems. Context menus are displayed in response to a user interface event, 
+	 * such as a right-click or a command-click on an InteractiveObject displayed in the application. The UI mechanism for showing the menu
+	 * varies by host operating system and hardware. Assign a menu to the <codeph class="+ topic/ph pr-d/codeph ">contextMenu</codeph> property of an
+	 * InteractiveObject. In AIR, a context menu can be created with either the NativeMenu class or the ContextMenu class. In
+	 * Flash Player, only the ContextMenu class can be used. ContextMenus in AIR do not have built-in items; a default context menu is
+	 * not displayed.</li><li class="- topic/li "><b class="+ topic/ph hi-d/b ">Pop-up menus</b> are supported on all operating systems. Pop-up menus are functionally the same as context menus, but
+	 * are displayed using the menu <codeph class="+ topic/ph pr-d/codeph ">display()</codeph> method rather than as a response to a user interface event. A pop-up
+	 * menu is not attached to any other object. Simply create the native menu and call the <codeph class="+ topic/ph pr-d/codeph ">display()</codeph> method.</li></ul><p class="- topic/p ">A menu object contains menu items. A menu item can represent a command, a submenu, or a separator line.
+	 * Add menu items to a menu using the <codeph class="+ topic/ph pr-d/codeph ">addItem()</codeph> or <codeph class="+ topic/ph pr-d/codeph ">addItemAt()</codeph> method. The display order of the menu items 
+	 * matches the order of the items in the menu's <codeph class="+ topic/ph pr-d/codeph ">items</codeph> array.</p><p class="- topic/p ">To create a submenu, add a menu item to the parent menu object. Assign the menu object representing 
+	 * the submenu to the <codeph class="+ topic/ph pr-d/codeph ">submenu</codeph> property of the matching menu item in the parent menu.</p><p class="- topic/p "><b class="+ topic/ph hi-d/b ">Note:</b> The root menu of window and application menus must contain only submenu items; items
+	 * that do not represent submenus may not be displayed and are contrary to user expectation for
+	 * these types of menus.</p><p class="- topic/p ">Menus dispatch <codeph class="+ topic/ph pr-d/codeph ">select</codeph> events when a command item in the menu or one of its
+	 * submenus is selected. (Submenu and separator items are not selectable.) The
+	 * <codeph class="+ topic/ph pr-d/codeph ">target</codeph> property of the event object references the 
+	 * selected item.</p><p class="- topic/p ">Menus dispatch <codeph class="+ topic/ph pr-d/codeph ">preparing</codeph> events just before the menu is displayed and when a key equivalent attached
+	 * to one of the items in the menu is pressed. You
+	 * can use this event to update the contents of the menu based on the current 
+	 * state of the application.</p><p class="- topic/p "><b class="+ topic/ph hi-d/b ">Note:</b> If you are using the Flex Framework, consider using the FlexNativeMenu class. 
+	 * It is typically easier to define menus declaratively in MXML than it is to write ActionScript code to create the menu 
+	 * structure item-by-item.</p>
+	 * @langversion	3.0
+	 * @playerversion	AIR 1.0
+	 */
+	public class NativeMenu extends EventDispatcher
+	{
+		/**
+		 * Creates a new NativeMenu object.
+		 * @langversion	3.0
+		 * @playerversion	AIR 1.0
+		 */
+		public function NativeMenu()
+		{
+			
+		}
+	}
+}

--- a/src/flash/display/Scene.as
+++ b/src/flash/display/Scene.as
@@ -1,0 +1,56 @@
+package flash.display
+{
+	/**
+	 * The Scene class includes properties for identifying the name, labels, and number of frames 
+	 * in a scene. A Scene object instance is created in Flash Professional, not by
+	 * writing ActionScript code.
+	 * The MovieClip class includes a <codeph class="+ topic/ph pr-d/codeph ">currentScene</codeph> property, which is 
+	 * a Scene object that identifies the scene in which the playhead is located in the 
+	 * timeline of the MovieClip instance. The <codeph class="+ topic/ph pr-d/codeph ">scenes</codeph> property of the 
+	 * MovieClip class is an array of Scene objects. Also, the <codeph class="+ topic/ph pr-d/codeph ">gotoAndPlay()</codeph> 
+	 * and <codeph class="+ topic/ph pr-d/codeph ">gotoAndStop()</codeph> methods of the MovieClip class use Scene objects as 
+	 * parameters.
+	 * @langversion	3.0
+	 * @playerversion	Flash 9
+	 * @playerversion	Lite 4
+	 */
+	public final class Scene extends Object
+	{
+		private var _labels:Array = [];
+		private var _name:String = "Scene 1";
+		private var _numFrames:int = 1;
+		
+		/**
+		 * An array of FrameLabel objects for the scene. Each FrameLabel object contains
+		 * a frame property, which specifies the frame number corresponding to the 
+		 * label, and a name property.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 */
+		public function get labels():Array { return _labels; }
+
+		/**
+		 * The name of the scene.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 */
+		public function get name():String { return _name; }
+
+		/**
+		 * The number of frames in the scene.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 */
+		public function get numFrames():int { return _numFrames; }
+
+		public function Scene (name:String, labels:Array, numFrames:int)
+		{
+			_name = name;
+			_labels = labels;
+			_numFrames = numFrames;
+		}
+	}
+}

--- a/src/flash/display/Sprite.as
+++ b/src/flash/display/Sprite.as
@@ -9,9 +9,14 @@ package flash.display
 	public class Sprite extends DisplayObjectContainer
 	{
 		public var graphics:Graphics = new Graphics;
-		private var tempPos:Point
+		private var tempPos:Point;
+		
 		public function Sprite()
 		{
+			super();
+			
+			DisplayObject.initStage = Stage.instance;
+			init();
 		}
 		
 		public function get buttonMode():Boolean  { return false }

--- a/src/flash/display/Stage.as
+++ b/src/flash/display/Stage.as
@@ -2,60 +2,263 @@ package flash.display
 {
 	import flash.__native.GLCanvasRenderingContext2D;
 	import flash.__native.WebGLRenderer;
-	import flash.events.Event;
-	import flash.events.EventDispatcher;
-	import flash.events.KeyboardEvent;
-	import flash.events.MouseEvent;
-	import flash.events.TouchEvent;
+	import flash.display.InteractiveObject;
 	import flash.geom.Rectangle;
-	import flash.utils.getTimer;
+	//import flash.media.StageVideo;
+	import flash.display.Stage3D;
+	import flash.display.DisplayObject;
+	import flash.geom.Transform;
+	import flash.accessibility.AccessibilityProperties;
+	import flash.accessibility.AccessibilityImplementation;
+	import flash.events.Event;
+	import flash.text.TextSnapshot;
+	import flash.ui.ContextMenu;
+	import flash.display.StageAlign;
+	import flash.display.BlendMode;
+	import flash.display.StageScaleMode;
+	import flash.events.MouseEvent;
+	import flash.events.Event;
+	import flash.events.TouchEvent;
+	import flash.events.KeyboardEvent;
 	
-	public class Stage extends EventDispatcher
+	/**
+	 * Dispatched by the Stage object when the state of the stageVideos property changes.
+	 * @eventType	flash.events.StageVideoAvailabilityEvent.STAGE_VIDEO_AVAILABILITY
+	 */
+	[Event(name="stageVideoAvailability", type="flash.events.StageVideoAvailabilityEvent")] 
+
+	/**
+	 * Dispatched by the Stage object when the stage orientation changes.
+	 * @eventType	flash.events.StageOrientationEvent.ORIENTATION_CHANGE
+	 */
+	[Event(name="orientationChange", type="flash.events.StageOrientationEvent")] 
+
+	/**
+	 * Dispatched by the Stage object when the stage orientation begins changing.
+	 * @eventType	flash.events.StageOrientationEvent.ORIENTATION_CHANGING
+	 */
+	[Event(name="orientationChanging", type="flash.events.StageOrientationEvent")] 
+
+	/**
+	 * Dispatched when the Stage object enters, or leaves, full-screen mode.
+	 * @eventType	flash.events.FullScreenEvent.FULL_SCREEN
+	 */
+	[Event(name="fullScreen", type="flash.events.FullScreenEvent")] 
+
+	/**
+	 * Dispatched when the scaleMode property of the Stage object is set to 
+	 * StageScaleMode.NO_SCALE and the SWF file is resized.
+	 * @eventType	flash.events.Event.RESIZE
+	 */
+	[Event(name="resize", type="flash.events.Event")] 
+
+	/**
+	 * Dispatched by the Stage object when the pointer moves out of the  
+	 * stage area.
+	 * @eventType	flash.events.Event.MOUSE_LEAVE
+	 */
+	[Event(name="mouseLeave", type="flash.events.Event")] 
+
+	/**
+	 * The Stage class represents the main drawing area.
+	 * 
+	 *   <p class="- topic/p ">For SWF content running in the browser (in 
+	 * Flash<sup class="+ topic/ph hi-d/sup ">®</sup> Player), the Stage represents the entire area where Flash 
+	 * content is shown. For content running in AIR on desktop operating systems, each NativeWindow object has a corresponding
+	 * Stage object.</p><p class="- topic/p ">The Stage object is not globally accessible. You need to access it through the
+	 * <codeph class="+ topic/ph pr-d/codeph ">stage</codeph> property of a DisplayObject instance.</p><p class="- topic/p ">The Stage class has several ancestor classes — DisplayObjectContainer, InteractiveObject, 
+	 * DisplayObject, and EventDispatcher — from which it inherits properties and methods. 
+	 * Many of these properties and methods are either inapplicable to Stage objects, 
+	 * or require security checks when called on a Stage object.  The properties and methods that 
+	 * require security checks are documented as part of the Stage class.</p><p class="- topic/p ">In addition, the following inherited properties are inapplicable to Stage objects. If you 
+	 * try to set them, an IllegalOperationError is thrown. These properties may always be read, but
+	 * since they cannot be set, they will always contain default values.</p><ul class="- topic/ul "><li class="- topic/li "><codeph class="+ topic/ph pr-d/codeph ">accessibilityProperties</codeph></li><li class="- topic/li "><codeph class="+ topic/ph pr-d/codeph ">alpha</codeph></li><li class="- topic/li "><codeph class="+ topic/ph pr-d/codeph ">blendMode</codeph></li><li class="- topic/li "><codeph class="+ topic/ph pr-d/codeph ">cacheAsBitmap</codeph></li><li class="- topic/li "><codeph class="+ topic/ph pr-d/codeph ">contextMenu</codeph></li><li class="- topic/li "><codeph class="+ topic/ph pr-d/codeph ">filters</codeph></li><li class="- topic/li "><codeph class="+ topic/ph pr-d/codeph ">focusRect</codeph></li><li class="- topic/li "><codeph class="+ topic/ph pr-d/codeph ">loaderInfo</codeph></li><li class="- topic/li "><codeph class="+ topic/ph pr-d/codeph ">mask</codeph></li><li class="- topic/li "><codeph class="+ topic/ph pr-d/codeph ">mouseEnabled</codeph></li><li class="- topic/li "><codeph class="+ topic/ph pr-d/codeph ">name</codeph></li><li class="- topic/li "><codeph class="+ topic/ph pr-d/codeph ">opaqueBackground</codeph></li><li class="- topic/li "><codeph class="+ topic/ph pr-d/codeph ">rotation</codeph></li><li class="- topic/li "><codeph class="+ topic/ph pr-d/codeph ">scale9Grid</codeph></li><li class="- topic/li "><codeph class="+ topic/ph pr-d/codeph ">scaleX</codeph></li><li class="- topic/li "><codeph class="+ topic/ph pr-d/codeph ">scaleY</codeph></li><li class="- topic/li "><codeph class="+ topic/ph pr-d/codeph ">scrollRect</codeph></li><li class="- topic/li "><codeph class="+ topic/ph pr-d/codeph ">tabEnabled</codeph></li><li class="- topic/li "><codeph class="+ topic/ph pr-d/codeph ">tabIndex</codeph></li><li class="- topic/li "><codeph class="+ topic/ph pr-d/codeph ">transform</codeph></li><li class="- topic/li "><codeph class="+ topic/ph pr-d/codeph ">visible</codeph></li><li class="- topic/li "><codeph class="+ topic/ph pr-d/codeph ">x</codeph></li><li class="- topic/li "><codeph class="+ topic/ph pr-d/codeph ">y</codeph></li></ul><p class="- topic/p ">Some events that you might expect to be a part of the Stage class,
+	 * such as <codeph class="+ topic/ph pr-d/codeph ">enterFrame</codeph>, <codeph class="+ topic/ph pr-d/codeph ">exitFrame</codeph>, 
+	 * <codeph class="+ topic/ph pr-d/codeph ">frameConstructed</codeph>, and <codeph class="+ topic/ph pr-d/codeph ">render</codeph>, 
+	 * cannot be Stage events because a reference to the Stage object
+	 * cannot be guaranteed to exist in every situation where these events
+	 * are used. Because these events cannot be dispatched by the Stage
+	 * object, they are instead dispatched by every DisplayObject instance,
+	 * which means that you can add an event listener to
+	 * any DisplayObject instance to listen for these events. 
+	 * These events, which are part of the DisplayObject class,
+	 * are called broadcast events to differentiate them from events 
+	 * that target a specific DisplayObject instance.
+	 * Two other broadcast events, <codeph class="+ topic/ph pr-d/codeph ">activate</codeph> and <codeph class="+ topic/ph pr-d/codeph ">deactivate</codeph>, 
+	 * belong to DisplayObject's superclass, EventDispatcher.
+	 * The <codeph class="+ topic/ph pr-d/codeph ">activate</codeph> and <codeph class="+ topic/ph pr-d/codeph ">deactivate</codeph> events
+	 * behave similarly to the DisplayObject broadcast events, except 
+	 * that these two events are dispatched not only by all DisplayObject
+	 * instances, but also by all EventDispatcher instances and instances
+	 * of other EventDispatcher subclasses.
+	 * For more information on broadcast events, see the DisplayObject class.</p>
+	 * 
+	 *   EXAMPLE:
+	 * 
+	 *   The following example uses the <codeph class="+ topic/ph pr-d/codeph ">StageExample</codeph> class to dispatch
+	 * events whenever the stage is activated or resized.  This is accomplished by performing the following steps:
+	 * <ol class="- topic/ol "><li class="- topic/li ">The class constructor first sets the Flash application to be fixed, regardless of the size of
+	 * the Flash Player window and then adds two event listeners with the 
+	 * <codeph class="+ topic/ph pr-d/codeph ">activateHandler()</codeph> and <codeph class="+ topic/ph pr-d/codeph ">resizeHandler()</codeph> methods.</li><li class="- topic/li ">The <codeph class="+ topic/ph pr-d/codeph ">activateHandler()</codeph> method runs when the left mouse button is clicked.</li><li class="- topic/li ">The <codeph class="+ topic/ph pr-d/codeph ">resizeHandler()</codeph> method runs when the stage is resized.</li></ol><codeblock xml:space="preserve" class="+ topic/pre pr-d/codeblock ">
+	 * package {
+	 * import flash.display.Sprite;
+	 * import flash.display.StageAlign;
+	 * import flash.display.StageScaleMode;
+	 * import flash.events.Event;
+	 * 
+	 *   public class StageExample extends Sprite {
+	 * 
+	 *   public function StageExample() {
+	 * stage.scaleMode = StageScaleMode.NO_SCALE;
+	 * stage.align = StageAlign.TOP_LEFT;
+	 * stage.addEventListener(Event.ACTIVATE, activateHandler);
+	 * stage.addEventListener(Event.RESIZE, resizeHandler);
+	 * }
+	 * 
+	 *   private function activateHandler(event:Event):void {
+	 * trace("activateHandler: " + event);
+	 * }
+	 * 
+	 *   private function resizeHandler(event:Event):void {
+	 * trace("resizeHandler: " + event);
+	 * trace("stageWidth: " + stage.stageWidth + " stageHeight: " + stage.stageHeight);
+	 * }
+	 * }
+	 * }
+	 * </codeblock>
+	 * @langversion	3.0
+	 * @playerversion	Flash 9
+	 * @playerversion	Lite 4
+	 */
+	public class Stage extends DisplayObjectContainer
 	{
+		private static var _instance:Stage;
+		private static var _instantiate:Boolean = false;
+		private static const kInvalidParamError:uint = 2004;
+		
 		public var __rootHtmlElement:Element;
 		public var __htmlWrapper:Element;
-		private var _frameRate:int;
-		private var _stage3Ds:Vector.<Stage3D>;
-		private static const kInvalidParamError:uint = 2004;
+		
 		private var _canvas:HTMLCanvasElement;
 		private var _ctx:CanvasRenderingContext2D
 		private var _ctx2d:CanvasRenderingContext2D
-		private var _mouseX:Number = 0;
-		private var _mouseY:Number = 0;
+		
 		//private var intervalID:Number;
 		private var needSendMouseMove:Boolean = false;
 		private var needSendTouchMove:Boolean = false;
 		private var lastUpdateTime:int = -1000;
 		//private var requestAnimationFrameHander:Number;
 		private var _loaderInfo:LoaderInfo;
-		private var _stageWidth:Number=0;
-		private var _stageHeight:Number=0;
+		
+		private var _align:String = StageAlign.TOP_LEFT;
+		private var _allowsFullScreen:Boolean = true;
+		private var _allowsFullScreenInteractive:Boolean = true;
+		private var _alpha:Number = 1;
+		private var _blendMode:String = BlendMode.NORMAL;
+		private var _browserZoomFactor:Number = 1;
+		private var _cacheAsBitmap:Boolean = false;
+		private var _color:uint = 0xFFFFFF;
+		private var _colorCorrection:String;
+		private var _colorCorrectionSupport:String;
+		private var _constructor:*;
+		private var _contentsScaleFactor:Number = 1;
+		private var _contextMenu:ContextMenu;
+		private var _displayContextInfo:String;
+		private var _displayState:String;
+		private var _filters:Array = [];
+		private var _focus:InteractiveObject;
+		private var _focusRect:Object;
+		private var _frameRate:int;
+		private var _fullScreenHeight:uint;
+		private var _fullScreenSourceRect:Rectangle;
+		private var _fullScreenWidth:uint;
+		private var _height:Number;
+		private var _mask:DisplayObject;
+		private var _mouseChildren:Boolean = true;
+		private var _mouseEnabled:Boolean = true;
+		private var _mouseLock:Boolean = false;
+		private var _mouseX:Number = 0;
+		private var _mouseY:Number = 0;
+		private var _name:String;
+		private var _opaqueBackground:Object;
+		private var _quality:String = StageQuality.BEST;
+		private var _rotation:Number = 0;
+		private var _rotationX:Number = 0;
+		private var _rotationY:Number = 0;
+		private var _rotationZ:Number = 0;
+		private var _scale9Grid:Rectangle;
+		private var _scaleMode:String = StageScaleMode.SHOW_ALL;
+		private var _scaleX:Number = 1;
+		private var _scaleY:Number = 1;
+		private var _scaleZ:Number = 1;
+		private var _scrollRect:Rectangle;
+		private var _showDefaultContextMenu:Boolean = true;
+		private var _softKeyboardRect:Rectangle;
+		private var _stage3Ds:Vector.<Stage3D>;
+		private var _stageFocusRec:Boolean = true;
+		private var _stageHeight:int = 0;
+		//private var _stageVideos:Vector.<StageVideo>;
+		private var _stageWidth:int = 0;
+		private var _tabChildren:Boolean = true;
+		private var _tabIndex:int = 0;
+		private var _tabEnabled:Boolean = true;
+		private var _textSnapshot:TextSnapshot;
+		private var _transform:Transform;
+		private var _visible:Boolean = true;
+		private var _width:Number;
+		private var _wmodeGPU:Boolean = true;
+		private var _x:Number = 0;
+		private var _y:Number = 0;
+		private var _z:Number = 0;
+		
+		/**
+		 * Stage is a singular instance per window and cannot be instantiated twice.
+		 */
 		public function Stage()
-		{
+		{	
+			super();
+			
+			if (_instance && !_instantiate) throw new Error("Stage is a singular instance and can't be instantiated twice. Access using instance.");
+			
 			trace("power by SpriteFlexJS");
+			
 			__rootHtmlElement = document.createElement("div");
 			document.body.appendChild(__rootHtmlElement);
 			
 			__htmlWrapper = document.createElement("div");
-			document.body.appendChild(__htmlWrapper);
 			__htmlWrapper.style.position = "absolute";
 			__htmlWrapper.style.left = "0px";
 			__htmlWrapper.style.top = "0px";
-			__htmlWrapper.style.zIndex =0;
+			__htmlWrapper.style.zIndex = 0;
+			document.body.appendChild(__htmlWrapper);
 			
 			_loaderInfo = new LoaderInfo();
-			if (SpriteFlexjs.startTime===0) {
-				SpriteFlexjs.startTime = Date.now();
-			}
-			frameRate = 60;
+			if (SpriteFlexjs.startTime===0)  SpriteFlexjs.startTime = Date.now();
+				
+			_frameRate = 60;
 			_stage3Ds = Vector.<Stage3D>([new Stage3D, new Stage3D, new Stage3D, new Stage3D]);
 			_stage3Ds[0].__stage = this;
 			_stage3Ds[1].__stage = this;
 			_stage3Ds[2].__stage = this;
 			_stage3Ds[3].__stage = this;
+			
 			window.addEventListener("resize", window_resize, false);
 			window.addEventListener("orientationchange", window_resize, false);
 			setTimeout(__update);
+			
+			_instance = this;
+		}
+		
+		public static function get instance():Stage
+		{
+			if (!_instance)
+			{
+				_instantiate = true;
+				_instance = new Stage();
+				_instantiate = false;
+			}
+			
+			return _instance;
 		}
 		
 		private function window_resize(e:Object):void
@@ -72,17 +275,6 @@ package flash.display
 			canvas.style.width = _stageWidth + "px";
 			canvas.style.height = _stageHeight + "px";
 			dispatchEvent(new Event(Event.RESIZE));
-		}
-		
-		public function get frameRate():Number  { return _frameRate }
-		
-		public function set frameRate(v:Number):void
-		{
-			_frameRate = v;
-			/*try{
-				cancelRequestAnimationFrame(requestAnimationFrameHander);
-			}catch(e:Object){}*/
-			//__update();
 		}
 		
 		private function __update():void {
@@ -110,52 +302,183 @@ package flash.display
 			//}
 		}
 		
-		public function invalidate():void  {/**/ }
+		public function set accessibilityImplementation (value:AccessibilityImplementation):void
+		{
+			
+		}
+
+		public function set accessibilityProperties (value:AccessibilityProperties):void
+		{
+			
+		}
+
+		/**
+		 * A value from the StageAlign class that specifies the alignment of the stage in
+		 * Flash Player or the browser. The following are valid values:
+		 * 
+		 *   ValueVertical AlignmentHorizontalStageAlign.TOPTopCenterStageAlign.BOTTOMBottomCenterStageAlign.LEFTCenterLeftStageAlign.RIGHTCenterRightStageAlign.TOP_LEFTTopLeftStageAlign.TOP_RIGHTTopRightStageAlign.BOTTOM_LEFTBottomLeftStageAlign.BOTTOM_RIGHTBottomRightThe align property is only available to an object that is in the same security sandbox 
+		 * as the Stage owner (the main SWF file).
+		 * To avoid this, the Stage owner can grant permission to the domain of the 
+		 * calling object by calling the Security.allowDomain() method or the Security.alowInsecureDomain() method.
+		 * For more information, see the "Security" chapter in the ActionScript 3.0 Developer's Guide.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 */
+		public function get align ():String { return _align; }
+		public function set align (value:String):void { _align = value; }
+
+		/**
+		 * Specifies whether this stage allows the use of the full screen mode
+		 * @langversion	3.0
+		 * @playerversion	Flash 10.2
+		 * @oldexample	The following example traces the value of this read-only property:
+		 *   <pre xml:space="preserve" class="- topic/pre ">
+		 *   trace(Stage.allowsFullsreen);
+		 *   </pre>
+		 */
+		public function get allowsFullScreen ():Boolean { return _allowsFullScreen; }
+
+		public function get allowsFullScreenInteractive ():Boolean { return _allowsFullScreenInteractive; }
 		
-		public function get loaderInfo():LoaderInfo  { return _loaderInfo; }
+		override public function set alpha(value:Number):void 
+		{
+			_alpha = value;
+			super.alpha = value;
+		}
 		
-		public function get scaleMode():String  { return null }
+		override public function set blendMode(value:String):void 
+		{
+			_blendMode = value;
+			super.blendMode = value;
+		}
 		
-		public function set scaleMode(param1:String):void  {/**/ }
+
+		public function get browserZoomFactor ():Number { return _browserZoomFactor; }
 		
-		public function get align():String  { return null }
-		
-		public function set align(param1:String):void  {/**/ }
-		
-		public function get stageWidth():int  { return _stageWidth; }
-		
-		public function set stageWidth(param1:int):void  {/**/ }
-		
-		public function get stageHeight():int  { return _stageHeight; }
-		
-		public function set stageHeight(param1:int):void  {/**/ }
-		
-		public function get showDefaultContextMenu():Boolean  { return false }
-		
-		public function set showDefaultContextMenu(param1:Boolean):void  {/**/ }
-		
-		public function get colorCorrection():String  { return null }
-		
-		public function set colorCorrection(param1:String):void  {/**/ }
-		
-		public function get colorCorrectionSupport():String  { return null }
-		
-		public function isFocusInaccessible():Boolean  { return false }
-		
-		public function get stageFocusRect():Boolean  { return false }
-		
-		public function set stageFocusRect(param1:Boolean):void  {/**/ }
-		
-		public function get quality():String  { return null }
-		
-		public function set quality(param1:String):void  {/**/ }
-		
-		public function get displayState():String  {
+		override public function set cacheAsBitmap(value:Boolean):void 
+		{
+			super.cacheAsBitmap = value;
+		}
+
+		public function get color ():uint { return _color; }
+		public function set color (color:uint):void { _color = color; }
+
+		/**
+		 * Controls Flash runtime color correction for displays.
+		 * Color correction works only if the main monitor is assigned a valid ICC color profile, which specifies 
+		 * the device's particular color attributes.
+		 * By default, the Flash runtime tries to match the color correction of its host (usually a browser).
+		 * 
+		 *   Use the Stage.colorCorrectionSupport property
+		 * to determine if color correction is available on the current system and the default state. 
+		 * .    If color correction is available, all colors on the stage are assumed to be in 
+		 * the sRGB color space, which is the most standard color space. Source profiles of input devices are not considered during color correction. 
+		 * No input color correction is applied; only the stage output is mapped to the main 
+		 * monitor's ICC color profile.In general, the benefits of activating color management include predictable and consistent color, better conversion, 
+		 * accurate proofing and more efficient cross-media output. Be aware, though, that color management does not provide 
+		 * perfect conversions due to devices having a different gamut from each other or original images. 
+		 * Nor does color management eliminate the need for custom or edited profiles. 
+		 * Color profiles are dependent on browsers, operating systems (OS), OS extensions, output devices, and application support.Applying color correction degrades the Flash runtime performance. 
+		 * A Flash runtime's color correction is document style color correction because
+		 * all SWF movies are considered documents with implicit sRGB profiles. 
+		 * Use the Stage.colorCorrectionSupport property to tell the Flash runtime 
+		 * to correct colors when displaying the SWF file (document) to the display color space.
+		 * Flash runtimes only compensates for differences between monitors, not for differences between input devices (camera/scanner/etc.).
+		 * The three possible values are strings with corresponding constants in the flash.display.ColorCorrection class:"default": Use the same color correction as the host system."on": Always perform color correction."off": Never perform color correction.
+		 * @langversion	3.0
+		 * @playerversion	Flash 10
+		 * @playerversion	AIR 1.5
+		 */
+		public function get colorCorrection ():String { return _colorCorrection; }
+		public function set colorCorrection (value:String):void { _colorCorrection = value; }
+
+		/**
+		 * Specifies whether the Flash runtime is running on an operating system that supports 
+		 * color correction and whether the color profile of the main (primary) 
+		 * monitor can be read and understood by the Flash runtime. This property also returns the default state
+		 * of color correction on the host system (usually the browser).
+		 * Currently the return values can be:
+		 * The three possible values are strings with corresponding constants in the flash.display.ColorCorrectionSupport class:"unsupported": Color correction is not available."defaultOn": Always performs color correction."defaultOff": Never performs color correction.
+		 * @langversion	3.0
+		 * @playerversion	Flash 10
+		 * @playerversion	AIR 1.5
+		 */
+		public function get colorCorrectionSupport ():String { return _colorCorrectionSupport; }
+
+		public function get constructor ():* { return _constructor; }
+		public function set constructor (c:*):void { _constructor = c; }
+
+		public function get contentsScaleFactor ():Number { return _contentsScaleFactor; }
+
+		public function set contextMenu (value:ContextMenu):void { _contextMenu = value; }
+
+		public function get displayContextInfo ():String { return _displayContextInfo; }
+
+		/**
+		 * A value from the StageDisplayState class that specifies which display state to use. The following
+		 * are valid values:
+		 * 
+		 *   StageDisplayState.FULL_SCREEN Sets AIR application or Flash runtime to expand the 
+		 * stage over the user's entire screen, with keyboard input disabled.StageDisplayState.FULL_SCREEN_INTERACTIVE Sets the AIR application to expand the 
+		 * stage over the user's entire screen, with keyboard input allowed. 
+		 * (Not available for content running in Flash Player.)StageDisplayState.NORMAL Sets the Flash runtime back to the standard stage display mode.The scaling behavior of the movie in full-screen mode is determined by the scaleMode 
+		 * setting (set using the Stage.scaleMode property or the SWF file's embed 
+		 * tag settings in the HTML file). If the scaleMode property is set to noScale 
+		 * while the application transitions to full-screen mode, the Stage width and height 
+		 * properties are updated, and the Stage dispatches a resize event. If any other scale mode is set,
+		 * the stage and its contents are scaled to fill the new screen dimensions. The Stage object retains its original
+		 * width and height values and does not dispatch a resize event.The following restrictions apply to SWF files that play within an HTML page (not those using the stand-alone 
+		 * Flash Player or not running in the AIR runtime):To enable full-screen mode, add the allowFullScreen parameter to the object 
+		 * and embed tags in the HTML page that includes the SWF file, with allowFullScreen set 
+		 * to "true", as shown in the following example:
+		 * 
+		 *   <codeblock>
+		 * <param name="allowFullScreen" value="true" />
+		 * ...
+		 * <embed src="example.swf" allowFullScreen="true" ... >
+		 * </codeblock>
+		 * An HTML page may also use a script to generate SWF-embedding tags. You need to alter the script 
+		 * so that it inserts the proper allowFullScreen settings. HTML pages generated by Flash Professional and  
+		 * Flash Builder use the AC_FL_RunContent() function to embed references to SWF files, and you 
+		 * need to add the allowFullScreen parameter settings, as in the following:
+		 * <codeblock>
+		 * AC_FL_RunContent( ... "allowFullScreen", "true", ... )
+		 * </codeblock>
+		 * Full-screen mode is initiated in response to a mouse click or key press by the user; the movie cannot change 
+		 * Stage.displayState without user input. Flash runtimes restrict keyboard input  in full-screen mode. 
+		 * Acceptable keys include keyboard shortcuts that terminate full-screen mode and non-printing keys such as arrows, space, Shift,
+		 * and Tab keys. Keyboard shortcuts that terminate full-screen mode are: Escape (Windows, Linux, and Mac), Control+W (Windows), 
+		 * Command+W (Mac), and Alt+F4.
+		 * A Flash runtime dialog box appears over the movie when users enter full-screen mode to inform the users they are in 
+		 * full-screen mode and that they can press the Escape key to end full-screen mode.Starting with Flash Player 9.0.115.0, full-screen works the same in windowless mode as it does in window mode. 
+		 * If you set the Window Mode (wmode in the HTML) to Opaque Windowless (opaque) 
+		 * or Transparent Windowless (transparent), full-screen can be initiated, 
+		 * but the full-screen window will always be opaque.These restrictions are not present for SWF content running in the 
+		 * stand-alone Flash Player or in AIR. AIR supports an interactive full-screen mode which allows keyboard input.For AIR content running in full-screen mode, the system screen saver
+		 * and power saving options are disabled while video content is playing and until either the video stops 
+		 * or full-screen mode is exited.On Linux, setting displayState to StageDisplayState.FULL_SCREEN or
+		 * StageDisplayState.FULL_SCREEN_INTERACTIVE is an asynchronous operation.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9.0.28.0
+		 * @playerversion	Lite 4
+		 * @throws	SecurityError Calling the displayState property of a Stage object throws an exception for
+		 *   any caller that is not in the same security sandbox as the Stage owner (the main SWF file).
+		 *   To avoid this, the Stage owner can grant permission to the domain of the caller by calling 
+		 *   the Security.allowDomain() method or the Security.allowInsecureDomain() method.
+		 *   For more information, see the "Security" chapter in the ActionScript 3.0 Developer's Guide.
+		 *   Trying to set the displayState property while the settings dialog is displayed, without a user response, or
+		 *   if the param or embed HTML tag's allowFullScreen attribute is not set to 
+		 *   true throws a security error.
+		 */
+		public function get displayState():String
+		{
 			return (document["fullscreen"] || document["webkitIsFullScreen"] || document["mozFullScreen"]) ? "fullScreen" : "normal";
 		}
 		
-		public function set displayState(param1:String):void  {
-			if (param1.indexOf("fullScreen")!=-1) {
+		public function set displayState (value:String):void
+		{
+			if (value.indexOf("fullScreen")!=-1) {
 				var requestFunc:Function = (_canvas["requestFullscreen"] || _canvas["webkitRequestFullScreen"] || _canvas["mozRequestFullScreen"] || _canvas["msRequestFullscreen"]);
 				requestFunc.call(_canvas);
 			} else {
@@ -163,40 +486,939 @@ package flash.display
 				cancelFunc.call(document);
 			}
 		}
+
+		//public function set filters (value:Array):void { return _filters; }
+		override public function set filters(value:Array):void 
+		{
+			_filters = value;
+		}
+
+		/**
+		 * The interactive object with keyboard focus; or null if focus is not set 
+		 * or if the focused object belongs to a security sandbox to which the calling object does not 
+		 * have access.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 * @throws	Error Throws an error if focus cannot be set to the target.
+		 */
+		public function get focus ():flash.display.InteractiveObject { return _focus; }
+		public function set focus (newFocus:InteractiveObject):void { _focus = newFocus; }
+
 		
-		public function get fullScreenSourceRect():Rectangle  { return null }
+		override public function set focusRect(value:Object):void 
+		{
+			_focusRect = value;
+		}
+
+		/**
+		 * Gets and sets the frame rate of the stage. The frame rate is defined as frames per second. 
+		 * By default the rate is set to the frame rate of the first SWF file loaded. Valid range for the frame rate 
+		 * is from 0.01 to 1000 frames per second.
+		 * 
+		 *   Note: An application might not be able to follow
+		 * high frame rate settings, either because the target platform is not fast enough or the player is
+		 * synchronized to the vertical blank timing of the display device (usually 60 Hz on LCD devices).
+		 * In some cases, a target platform might also choose to lower the maximum frame rate if it 
+		 * anticipates high CPU usage.For content running in Adobe AIR, setting the frameRate property of one Stage
+		 * object changes the frame rate for all Stage objects (used by different NativeWindow objects).
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 * @throws	SecurityError Calling the frameRate property of a Stage object throws an exception for
+		 *   any caller that is not in the same security sandbox as the Stage owner (the main SWF file).
+		 *   To avoid this, the Stage owner can grant permission to the domain of the caller by calling 
+		 *   the Security.allowDomain() method or the Security.allowInsecureDomain() method.
+		 *   For more information, see the "Security" chapter in the ActionScript 3.0 Developer's Guide.
+		 */
+		public function get frameRate ():Number { return _frameRate; }
+		public function set frameRate (value:Number):void { _frameRate = value; }
+
+		/**
+		 * Returns the height of the monitor that will be used when going to full screen size, if that state 
+		 * is entered immediately. If the user has multiple monitors, the monitor that's used is the 
+		 * monitor that most of the stage is on at the time.
+		 * 
+		 *   Note: If the user has the opportunity to move the browser from one 
+		 * monitor to another between retrieving the value and going to full screen
+		 * size, the value could be incorrect. If you retrieve the value in an event handler that
+		 * sets Stage.displayState to StageDisplayState.FULL_SCREEN, the value will be
+		 * correct.This is the pixel height of the monitor and is the same as the 
+		 * stage height would be if Stage.align is set to StageAlign.TOP_LEFT
+		 * and Stage.scaleMode is set to StageScaleMode.NO_SCALE.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9.0.115.0
+		 * @playerversion	Lite 4
+		 */
+		public function get fullScreenHeight ():uint { return _fullScreenHeight; }
+
+		/**
+		 * Sets the Flash runtime to scale a specific region of the stage to full-screen mode. 
+		 * If available, the Flash runtime scales in hardware, which uses the graphics and video card on a user's computer,
+		 * and generally displays content more quickly than software scaling.
+		 * 
+		 *   When this property is set to a valid rectangle and the displayState property is set to full-screen mode, 
+		 * the Flash runtime scales the specified area. The actual Stage size in pixels within ActionScript does not change.
+		 * The Flash runtime enforces a minimum limit for the size of the rectangle to accommodate the standard "Press Esc to exit full-screen mode" message.
+		 * This limit is usually around 260 by 30 pixels but can vary on platform and Flash runtime version.This property can only be set when the Flash runtime is not in full-screen mode. 
+		 * To use this property correctly, set this property first, then set the displayState property to full-screen mode, as shown in the code examples.To enable scaling, set the fullScreenSourceRect property to a rectangle object:
+		 * <codeblock>
+		 * 
+		 *   // valid, will enable hardware scaling
+		 * stage.fullScreenSourceRect = new Rectangle(0,0,320,240);
+		 * 
+		 *   </codeblock>
+		 * To disable scaling, set the fullScreenSourceRect=null in ActionScript 3.0, and undefined in ActionScript 2.0.
+		 * <codeblock>
+		 * 
+		 *   stage.fullScreenSourceRect = null;
+		 * 
+		 *   </codeblock>
+		 * The end user also can select within Flash Player Display Settings to turn off hardware scaling, which is enabled by default. 
+		 * For more information, see www.adobe.com/go/display_settings.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9.0.115.0
+		 * @playerversion	Lite 4
+		 */
+		public function get fullScreenSourceRect ():flash.geom.Rectangle { return _fullScreenSourceRect; }
+		public function set fullScreenSourceRect (value:Rectangle):void { _fullScreenSourceRect = value; }
+
+		/**
+		 * Returns the width of the monitor that will be used when going to full screen size, if that state 
+		 * is entered immediately. If the user has multiple monitors, the monitor that's used is the
+		 * monitor that most of the stage is on at the time.
+		 * 
+		 *   Note: If the user has the opportunity to move the browser from one 
+		 * monitor to another between retrieving the value and going to full screen
+		 * size, the value could be incorrect. If you retrieve the value in an event handler that
+		 * sets Stage.displayState to StageDisplayState.FULL_SCREEN, the value will be
+		 * correct.This is the pixel width of the monitor and is the same as the stage width would be if 
+		 * Stage.align is set to StageAlign.TOP_LEFT and 
+		 * Stage.scaleMode is set to StageScaleMode.NO_SCALE.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9.0.115.0
+		 * @playerversion	Lite 4
+		 */
+		public function get fullScreenWidth ():uint { return _fullScreenWidth; }
+
+		/**
+		 * Indicates the height of the display object, in pixels. The height is calculated based on the bounds of the content of the display object.
+		 * When you set the height property, the scaleY property is adjusted accordingly, as shown in the 
+		 * following code:
+		 * 
+		 *   <codeblock>
+		 * 
+		 *   var rect:Shape = new Shape();
+		 * rect.graphics.beginFill(0xFF0000);
+		 * rect.graphics.drawRect(0, 0, 100, 100);
+		 * trace(rect.scaleY) // 1;
+		 * rect.height = 200;
+		 * trace(rect.scaleY) // 2;
+		 * </codeblock>
+		 * Except for TextField and Video objects, a display object with no content (such as an empty sprite) has a height 
+		 * of 0, even if you try to set height to a different value.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 * @throws	SecurityError Referencing the height property of a Stage object throws an exception for
+		 *   any caller that is not in the same security sandbox as the Stage owner (the main SWF file).
+		 *   To avoid this, the Stage owner can grant permission to the domain of the caller by calling 
+		 *   the Security.allowDomain() method or the Security.allowInsecureDomain() method.
+		 *   For more information, see the "Security" chapter in the ActionScript 3.0 Developer's Guide.
+		 * @throws	IllegalOperationError It is always illegal to set the height property of a Stage object,
+		 *   even if the calling object is the Stage owner (the main SWF file).
+		 */
+		override public function get height():Number 
+		{
+			return _height;
+		}
 		
-		public function set fullScreenSourceRect(param1:Rectangle):void  {/**/ }
+		override public function set height(value:Number):void 
+		{
+			_height = value;
+			super.height = _height;
+		}
 		
-		public function get mouseLock():Boolean  { return false }
+		override public function set mask(value:DisplayObject):void 
+		{
+			_mask = value;
+			super.mask = value;
+		}
+
+		/**
+		 * Determines whether or not the children of the object are mouse, or user input device, enabled. 
+		 * If an object is enabled, a user can interact with it by using a mouse or user input device. The default is true.
+		 * 
+		 *   This property is useful when you create a button with an instance of the Sprite class
+		 * (instead of using the SimpleButton class). When you use a Sprite instance to create a button,
+		 * you can choose to decorate the button by using the addChild() method to add additional
+		 * Sprite instances. This process can cause unexpected behavior with mouse events because
+		 * the Sprite instances you add as children can become the target object of a mouse event
+		 * when you expect the parent instance to be the target object. To ensure that the parent
+		 * instance serves as the target objects for mouse events, you can set the 
+		 * mouseChildren property of the parent instance to false. No event is dispatched by setting this property. You must use the
+		 * addEventListener() method to create interactive functionality.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 * @throws	SecurityError Referencing the mouseChildren property of a Stage object throws an exception for
+		 *   any caller that is not in the same security sandbox as the Stage owner (the main SWF file).
+		 *   To avoid this, the Stage owner can grant permission to the domain of the caller by calling 
+		 *   the Security.allowDomain() method or the Security.allowInsecureDomain() method.
+		 *   For more information, see the "Security" chapter in the ActionScript 3.0 Developer's Guide.
+		 */
+		override public function get mouseChildren():Boolean 
+		{
+			return super.mouseChildren;
+		}
 		
-		public function set mouseLock(param1:Boolean):void  {/**/ }
+		override public function set mouseChildren(value:Boolean):void 
+		{
+			_mouseChildren = value;
+			super.mouseChildren = value;
+		}
 		
-		// public function get stageVideos() : Vector.<StageVideo>{return null}
+		override public function set mouseEnabled(value:Boolean):void 
+		{
+			_mouseEnabled = value;
+			super.mouseEnabled = value;
+		}
 		
-		public function get stage3Ds():Vector.<Stage3D>  { return _stage3Ds }
+		public function get mouseLock ():Boolean { return _mouseLock; }
+		public function set mouseLock (value:Boolean):void { _mouseLock = value; }
 		
-		public function get color():uint  { return 0 }
+		override public function get mouseX():Number { return _mouseX; }
+		override public function get mouseY():Number { return _mouseY; }
 		
-		public function set color(param1:uint):void  {/**/ }
+		override public function set name(value:String):void 
+		{
+			_name = value;
+			super.name = value;
+		}
+
+		/**
+		 * Returns the number of children of this object.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 * @throws	SecurityError Referencing the numChildren property of a Stage object throws an exception for
+		 *   any caller that is not in the same security sandbox as the Stage owner (the main SWF file).
+		 *   To avoid this, the Stage owner can grant permission to the domain of the caller by calling 
+		 *   the Security.allowDomain() method or the Security.allowInsecureDomain() method.
+		 *   For more information, see the "Security" chapter in the ActionScript 3.0 Developer's Guide.
+		 */
+		override public function get numChildren():int 
+		{
+			return super.numChildren;
+		}
 		
-		public function get fullScreenWidth():uint  { return 0 }
+		override public function set opaqueBackground(value:Object):void 
+		{
+			_opaqueBackground = value;
+			super.opaqueBackground = value;
+		}
+
+		/**
+		 * A value from the StageQuality class that specifies which rendering quality is used.
+		 * The following are valid values:
+		 * 
+		 *   StageQuality.LOW—Low rendering quality. Graphics are not
+		 * anti-aliased, and bitmaps are not smoothed, but runtimes still use mip-mapping.StageQuality.MEDIUM—Medium rendering quality. Graphics are
+		 * anti-aliased using a 2 x 2 pixel grid, bitmap smoothing is dependent on the Bitmap.smoothing setting.
+		 * Runtimes use mip-mapping. This setting is suitable for movies that do not contain text.StageQuality.HIGH—High rendering quality. Graphics are anti-aliased
+		 * using a 4 x 4 pixel grid, and bitmap smoothing is dependent on the Bitmap.smoothing setting.
+		 * Runtimes use mip-mapping. This is the default rendering quality setting that Flash Player uses.StageQuality.BEST—Very high rendering quality. Graphics are
+		 * anti-aliased using a 4 x 4 pixel grid. If Bitmap.smoothing is true the runtime uses a high quality 
+		 * downscale algorithm that produces fewer artifacts (however, using StageQuality.BEST with Bitmap.smoothing set to true
+		 * slows performance significantly and is not a recommended setting).Higher quality settings produce better rendering of scaled bitmaps. However, higher 
+		 * quality settings are computationally more expensive. In particular, when rendering scaled video, 
+		 * using higher quality settings can reduce the frame rate.
+		 * In the desktop profile of Adobe AIR, quality can be set 
+		 * to StageQuality.BEST or StageQuality.HIGH (and the default value 
+		 * is StageQuality.HIGH). Attempting to set it to another value has no effect 
+		 * (and the property remains unchanged). In the moble profile of AIR, all four quality settings
+		 * are available. The default value on mobile devices is StageQuality.MEDIUM.For content running in Adobe AIR, setting the quality property of one Stage
+		 * object changes the rendering quality for all Stage objects (used by different NativeWindow objects).
+		 * Note: The operating system draws the device fonts, 
+		 * which are therefore unaffected by the quality property.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 * @throws	SecurityError Calling the quality property of a Stage object throws an exception for
+		 *   any caller that is not in the same security sandbox as the Stage owner (the main SWF file).
+		 *   To avoid this, the Stage owner can grant permission to the domain of the caller by calling 
+		 *   the Security.allowDomain() method or the Security.allowInsecureDomain() method.
+		 *   For more information, see the "Security" chapter in the ActionScript 3.0 Developer's Guide.
+		 */
+		public function get quality ():String { return _quality; }
+		public function set quality (value:String):void { _quality = value; }
+
+		//public function set rotation (value:Number):void;
+		override public function set rotation(value:Number):void 
+		{
+			_rotation = value;
+			super.rotation = value;
+		}
 		
-		public function get fullScreenHeight():uint  { return 0 }
+		override public function set rotationX(value:Number):void 
+		{
+			_rotationX = value;
+			super.rotationX = value;
+		}
 		
-		public function get wmodeGPU():Boolean  { return false }
+		override public function set rotationY(value:Number):void 
+		{
+			_rotationY = value;
+			super.rotationY = value;
+		}
 		
-		public function get softKeyboardRect():Rectangle  { return null }
+		override public function set rotationZ(value:Number):void 
+		{
+			_rotationZ = value;
+			super.rotationZ = value;
+		}
 		
-		public function get allowsFullScreen():Boolean  { return false }
+		override public function set scale9Grid(value:Rectangle):void 
+		{
+			_scale9Grid = value;
+			super.scale9Grid = value;
+		}
+
+		/**
+		 * A value from the StageScaleMode class that specifies which scale mode to use.
+		 * The following are valid values:
+		 * 
+		 *   StageScaleMode.EXACT_FIT—The entire application is visible
+		 * in the specified area without trying to preserve the original aspect ratio. Distortion can occur, and the application may appear stretched or compressed.
+		 * StageScaleMode.SHOW_ALL—The entire application is visible 
+		 * in the specified area without distortion while maintaining the original aspect ratio of the application. 
+		 * Borders can appear on two sides of the application.   
+		 * StageScaleMode.NO_BORDER—The entire application fills the specified area, 
+		 * without distortion but possibly with some cropping, while maintaining the original aspect ratio 
+		 * of the application.
+		 * StageScaleMode.NO_SCALE—The entire application is fixed, so that 
+		 * it remains unchanged even as the size of the player window changes. Cropping might 
+		 * occur if the player window is smaller than the content.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 * @throws	SecurityError Calling the scaleMode property of a Stage object throws an exception for
+		 *   any caller that is not in the same security sandbox as the Stage owner (the main SWF file).
+		 *   To avoid this, the Stage owner can grant permission to the domain of the caller by calling 
+		 *   the Security.allowDomain() method or the Security.allowInsecureDomain() method.
+		 *   For more information, see the "Security" chapter in the ActionScript 3.0 Developer's Guide.
+		 */
+		public function get scaleMode ():String { return _scaleMode; }
+		public function set scaleMode (value:String):void { _scaleMode = value; }
 		
-		public function get allowsFullScreenInteractive():Boolean  { return false }
+		override public function set scaleX(value:Number):void 
+		{
+			_scaleX = value;
+			super.scaleX = value;
+		}
+
+		override public function set scaleY (value:Number):void
+		{
+			_scaleY = value;
+			super.scaleY = value;
+		}
+
+		override public function set scaleZ (value:Number):void
+		{
+			_scaleZ = value;
+			super.scaleZ = value;
+		}
 		
-		public function get contentsScaleFactor():Number  { return 0 }
+		override public function set scrollRect(value:Rectangle):void 
+		{
+			_scrollRect = value;
+			super.scrollRect = value;
+		}
+
+		/**
+		 * Specifies whether to show or hide the default items in the Flash runtime 
+		 * context menu.
+		 * 
+		 *   If the showDefaultContextMenu property is set to true (the 
+		 * default), all context menu items appear. If the showDefaultContextMenu property 
+		 * is set to false, only the Settings and About... menu items appear.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @throws	SecurityError Calling the showDefaultContextMenu property of a Stage object throws an exception for
+		 *   any caller that is not in the same security sandbox as the Stage owner (the main SWF file).
+		 *   To avoid this, the Stage owner can grant permission to the domain of the caller by calling 
+		 *   the Security.allowDomain() method or the Security.allowInsecureDomain() method.
+		 *   For more information, see the "Security" chapter in the ActionScript 3.0 Developer's Guide.
+		 */
+		public function get showDefaultContextMenu ():Boolean { return _showDefaultContextMenu; }
+		public function set showDefaultContextMenu (value:Boolean):void { _showDefaultContextMenu = value; }
+
+		/**
+		 * The area of the stage that is currently covered by the software keyboard.
+		 * 
+		 *   The area has a size of zero (0,0,0,0) when the soft keyboard is not visible.When the keyboard opens, the softKeyboardRect is set at the time the
+		 * softKeyboardActivate event is dispatched. If the keyboard changes size while open,
+		 * the runtime updates the softKeyboardRect property and dispatches an 
+		 * additional softKeyboardActivate event.Note: On Android, the area covered by the keyboard is estimated when
+		 * the operating system does not provide the information necessary to determine the exact
+		 * area. This problem occurs in fullscreen mode and also when the keyboard opens in response to 
+		 * an InteractiveObject receiving focus or invoking the requestSoftKeyboard() method.
+		 * @langversion	3.0
+		 * @playerversion	AIR 2.6
+		 * @playerversion	Flash 10.2
+		 */
+		public function get softKeyboardRect ():flash.geom.Rectangle { return _softKeyboardRect; }
+
+		public function get stage3Ds ():Vector.<Stage3D> { return _stage3Ds; }
+
+		/**
+		 * Specifies whether or not objects display a glowing border when they have focus.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 * @throws	SecurityError Calling the stageFocusRect property of a Stage object throws an exception for
+		 *   any caller that is not in the same security sandbox as the Stage owner (the main SWF file).
+		 *   To avoid this, the Stage owner can grant permission to the domain of the caller by calling 
+		 *   the Security.allowDomain() method or the Security.allowInsecureDomain() method.
+		 *   For more information, see the "Security" chapter in the ActionScript 3.0 Developer's Guide.
+		 */
+		public function get stageFocusRect ():Boolean { return _stageFocusRec; }
+		public function set stageFocusRect (on:Boolean):void { _stageFocusRec = on; }
+
+		/**
+		 * The current height, in pixels, of the Stage.
+		 * 
+		 *   If the value of the Stage.scaleMode property is set to StageScaleMode.NO_SCALE
+		 * when the user resizes the window, the Stage content maintains its size while the 
+		 * stageHeight property changes to reflect the new height size of the screen area occupied by 
+		 * the SWF file. (In the other scale modes, the stageHeight property always reflects the original 
+		 * height of the SWF file.) You can add an event listener for the resize event and then use the 
+		 * stageHeight property of the Stage class to determine the actual pixel dimension of the resized 
+		 * Flash runtime window. The event listener allows you to control how 
+		 * the screen content adjusts when the user resizes the window.Air for TV devices have slightly different behavior than desktop devices
+		 * when you set the stageHeight property.
+		 * If the Stage.scaleMode
+		 * property is set to StageScaleMode.NO_SCALE and you set the stageHeight
+		 * property, the stage height does not change until the next 
+		 * frame of the SWF.Note: In an HTML page hosting the SWF file, both the object and embed tags' height attributes must be set to a percentage (such as 100%), not pixels. If the 
+		 * settings are generated by JavaScript code, the height parameter of the AC_FL_RunContent()
+		 * method must be set to a percentage, too. This percentage is applied to the stageHeight
+		 * value.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 * @throws	SecurityError Calling the stageHeight property of a Stage object throws an exception for
+		 *   any caller that is not in the same security sandbox as the Stage owner (the main SWF file).
+		 *   To avoid this, the Stage owner can grant permission to the domain of the caller by calling 
+		 *   the Security.allowDomain() method or the Security.allowInsecureDomain() method.
+		 *   For more information, see the "Security" chapter in the ActionScript 3.0 Developer's Guide.
+		 */
+		public function get stageHeight ():int { return _stageHeight; }
+		public function set stageHeight (value:int):void { _stageHeight = value; }
+
+		/**
+		 * A list of StageVideo objects available for playing external videos.
+		 * 
+		 *   You can use only a limited number of StageVideo objects at a time.
+		 * When a SWF begins to run, the number of available StageVideo objects depends on the platform 
+		 * and on available hardware. 
+		 * To use a StageVideo object, assign a member of the stageVideos Vector object to a StageVideo variable.
+		 * All StageVideo objects are displayed on the stage behind any display objects. 
+		 * The StageVideo objects are displayed on the stage in the order they appear in
+		 * the stageVideos Vector object. For example, if the stageVideos Vector object contains
+		 * three entries:The StageVideo object in the 0 index of the stageVideos Vector object is 
+		 * displayed behind all StageVideo objects.The StageVideo object at index 1 is displayed in front 
+		 * of the StageVideo object at index 0.The StageVideo object at index 2 is displayed in front 
+		 * of the StageVideo object at index 1.Use the StageVideo.depth property to change this ordering.Note: AIR for TV devices support only one StageVideo object.
+		 * @langversion	3.0
+		 * @playerversion	AIR 2.5
+		 */
+		//public function get stageVideos ():Vector.<flash.media.StageVideo>;
+
+		/**
+		 * Specifies the current width, in pixels, of the Stage.
+		 * 
+		 *   If the value of the Stage.scaleMode property is set to StageScaleMode.NO_SCALE
+		 * when the user resizes the window, the Stage content maintains its defined size while the stageWidth 
+		 * property changes to reflect the new width size of the screen area occupied by the SWF file. (In the other scale
+		 * modes, the stageWidth property always reflects the original width of the SWF file.) You can add an event 
+		 * listener for the resize event and then use the stageWidth property of the Stage class to
+		 * determine the actual pixel dimension of the resized Flash runtime window. The event listener allows you to control how 
+		 * the screen content adjusts when the user resizes the window.Air for TV devices have slightly different behavior than desktop devices
+		 * when you set the stageWidth property.
+		 * If the Stage.scaleMode
+		 * property is set to StageScaleMode.NO_SCALE and you set the stageWidth
+		 * property, the stage width does not change until the next 
+		 * frame of the SWF.Note: In an HTML page hosting the SWF file, both the object and embed tags' width attributes must be set to a percentage (such as 100%), not pixels. If the 
+		 * settings are generated by JavaScript code, the width parameter of the AC_FL_RunContent()
+		 * method must be set to a percentage, too. This percentage is applied to the stageWidth
+		 * value.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 * @throws	SecurityError Calling the stageWidth property of a Stage object throws an exception for
+		 *   any caller that is not in the same security sandbox as the Stage owner (the main SWF file).
+		 *   To avoid this, the Stage owner can grant permission to the domain of the caller by calling 
+		 *   the Security.allowDomain() method or the Security.allowInsecureDomain() method.
+		 *   For more information, see the "Security" chapter in the ActionScript 3.0 Developer's Guide.
+		 */
+		public function get stageWidth ():int { return _stageWidth; }
+		public function set stageWidth (value:int):void { _stageWidth = value; }
+
+		/**
+		 * Determines whether the children of the object are tab enabled. Enables or disables tabbing for the 
+		 * children of the object. The default is true.
+		 * Note: Do not use the tabChildren property with Flex.
+		 * Instead, use the mx.core.UIComponent.hasFocusableChildren property.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @throws	SecurityError Referencing the tabChildren property of a Stage object throws an exception for
+		 *   any caller that is not in the same security sandbox as the Stage owner (the main SWF file). 
+		 *   To avoid this, the Stage owner can grant permission to the domain of the caller by calling 
+		 *   the Security.allowDomain() method or the Security.allowInsecureDomain() method.
+		 *   For more information, see the "Security" chapter in the ActionScript 3.0 Developer's Guide.
+		 */
+		override public function get tabChildren():Boolean 
+		{
+			return super.tabChildren;
+		}
 		
-		public function get browserZoomFactor():Number  { return 0 }
+		override public function set tabChildren(value:Boolean):void 
+		{
+			_tabChildren = value;
+			super.tabChildren = value;
+		}
 		
-		private function requireOwnerPermissions():void  {/**/ }
+		override public function set tabEnabled(value:Boolean):void 
+		{
+			_tabEnabled = value;
+			super.tabEnabled = value;
+		}
+		
+		override public function set tabIndex(value:int):void 
+		{
+			_tabIndex = value;
+			super.tabIndex = value;
+		}
+
+		/**
+		 * Returns a TextSnapshot object for this DisplayObjectContainer instance.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @throws	IllegalOperationError Referencing the textSnapshot property of a Stage object throws an 
+		 *   exception because the Stage class does not implement this property. To avoid this, call the 
+		 *   textSnapshot property of a display object container other than the Stage object.
+		 */
+		public function get textSnapshot ():flash.text.TextSnapshot { return _textSnapshot; }
+
+		public function set transform (value:Transform):void { _transform = value; }
+
+		override public function set visible(value:Boolean):void 
+		{
+			_visible = value;
+			super.visible = value;
+		}
+
+		/**
+		 * Indicates the width of the display object, in pixels. The width is calculated based on the bounds of the content of the display object.
+		 * When you set the width property, the scaleX property is adjusted accordingly, as shown in the 
+		 * following code:
+		 * 
+		 *   <codeblock>
+		 * 
+		 *   var rect:Shape = new Shape();
+		 * rect.graphics.beginFill(0xFF0000);
+		 * rect.graphics.drawRect(0, 0, 100, 100);
+		 * trace(rect.scaleX) // 1;
+		 * rect.width = 200;
+		 * trace(rect.scaleX) // 2;
+		 * </codeblock>
+		 * Except for TextField and Video objects, a display object with no content (such as an empty sprite) has a width 
+		 * of 0, even if you try to set width to a different value.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 * @throws	SecurityError Referencing the width property of a Stage object throws an exception for
+		 *   any caller that is not in the same security sandbox as the Stage owner (the main SWF file).
+		 *   To avoid this, the Stage owner can grant permission to the domain of the caller by calling 
+		 *   the Security.allowDomain() method or the Security.allowInsecureDomain() method.
+		 *   For more information, see the "Security" chapter in the ActionScript 3.0 Developer's Guide.
+		 * @throws	IllegalOperationError It is always illegal to set the width property of a Stage object,
+		 *   even if you are the Stage owner.
+		 */
+		override public function get width():Number 
+		{
+			return super.width;
+		}
+		
+		override public function set width(value:Number):void 
+		{
+			_width = value;
+			super.width = value;
+		}
+
+		/**
+		 * Indicates whether GPU compositing is available and in use. The wmodeGPU value is trueonly
+		 * when all three of the following conditions exist:
+		 * GPU compositing has been requested.GPU compositing is available.GPU compositing is in use.Specifically, the wmodeGPU property indicates one of the following:GPU compositing has not been requested or is unavailable. In this case, the wmodeGPU property value is false.GPU compositing has been requested (if applicable and available), but the environment is operating in "fallback mode" 
+		 * (not optimal rendering) due to limitations of the content. In this case, the wmodeGPU property value is true.GPU compositing has been requested (if applicable and available), and the environment is operating in the best mode. In this case, the 
+		 * wmodeGPU property value is also true.In other words, the wmodeGPU property identifies the capability and state of the rendering environment. For runtimes 
+		 * that do not support GPU compositing, such as AIR 1.5.2, the value is always false, because (as stated above) the value is 
+		 * true only when GPU compositing has been requested, is available, and is in use.The wmodeGPU property is useful to determine, at runtime, whether or not GPU compositing is in use. The value of 
+		 * wmodeGPU indicates if your content is going to be scaled by hardware, or not, so you can present graphics at the correct size.
+		 * You can also determine if you're rendering in a fast path or not, so that you can adjust your content complexity accordingly.For Flash Player in a browser, GPU compositing can be requested by the value of gpu for the wmode HTML 
+		 * parameter in the page hosting the SWF file. For other configurations, GPU compositing can be requested in the header of a SWF file 
+		 * (set using SWF authoring tools).However, the wmodeGPU property does not identify the current rendering performance. Even if GPU compositing is "in use" the rendering 
+		 * process might not be operating in the best mode. To adjust your content for optimal rendering, use a Flash runtime debugger version, 
+		 * and set the DisplayGPUBlendsetting in your mm.cfg file.Note: This property is always false when referenced
+		 * from ActionScript that runs before the runtime performs its first rendering
+		 * pass.  For example, if you examine wmodeGPU from a script in Frame 1 of
+		 * Adobe Flash Professional, and your SWF file is the first SWF file loaded in a new
+		 * instance of the runtime, then the wmodeGPU value is false.
+		 * To get an accurate value, wait until at least one rendering pass
+		 * has occurred. If you write an event listener for the
+		 * exitFrame event of any DisplayObject, the wmodeGPU value at
+		 * is the correct value.
+		 * @langversion	3.0
+		 * @playerversion	Flash 10.0.32
+		 * @playerversion	AIR 1.5.2
+		 * @playerversion	Lite 4
+		 */
+		public function get wmodeGPU ():Boolean { return _wmodeGPU; }
+		
+		override public function set x(value:Number):void 
+		{
+			_x = value;
+			super.x = value;
+		}
+		
+		override public function set y(value:Number):void 
+		{
+			_y = value;
+			super.y = value;
+		}
+		
+		override public function set z(value:Number):void 
+		{
+			_z = value;
+			super.z = value;
+		}
+
+		/**
+		 * Adds a child DisplayObject instance to this DisplayObjectContainer instance. The child is added
+		 * to the front (top) of all other children in this DisplayObjectContainer instance. (To add a child to a 
+		 * specific index position, use the addChildAt() method.)
+		 * 
+		 *   If you add a child object that already has a different display object container as
+		 * a parent, the object is removed from the child list of the other display object container. Note: The command stage.addChild() can cause problems with a published SWF file,
+		 * including security problems and conflicts with other loaded SWF files. There is only one Stage within a Flash runtime instance, 
+		 * no matter how many SWF files you load into the runtime. So, generally, objects
+		 * should not be added to the Stage, directly, at all. The only object the Stage should
+		 * contain is the root object. Create a DisplayObjectContainer to contain all of the items on the
+		 * display list. Then, if necessary, add that DisplayObjectContainer instance to the Stage.
+		 * @param	child	The DisplayObject instance to add as a child of this DisplayObjectContainer instance.
+		 * @return	The DisplayObject instance that you pass in the 
+		 *   child parameter.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 * @throws	SecurityError Calling the addChild() method of a Stage object throws an exception for
+		 *   any caller that is not in the same security sandbox as the Stage owner (the main SWF file).
+		 *   To avoid this, the Stage owner can grant permission to the domain of the caller by calling 
+		 *   the Security.allowDomain() method or the Security.allowInsecureDomain() method.
+		 *   For more information, see the "Security" chapter in the ActionScript 3.0 Developer's Guide.
+		 */
+		override public function addChild(child:DisplayObject):DisplayObject 
+		{
+			return super.addChild(child);
+		}
+
+		/**
+		 * Adds a child DisplayObject instance to this DisplayObjectContainer 
+		 * instance.  The child is added
+		 * at the index position specified. An index of 0 represents the back (bottom) 
+		 * of the display list for this DisplayObjectContainer object.
+		 * 
+		 *   For example, the following example shows three display objects, labeled a, b, and c, at
+		 * index positions 0, 2, and 1, respectively:If you add a child object that already has a different display object container as
+		 * a parent, the object is removed from the child list of the other display object container.
+		 * @param	child	The DisplayObject instance to add as a child of this 
+		 *   DisplayObjectContainer instance.
+		 * @param	index	The index position to which the child is added. If you specify a 
+		 *   currently occupied index position, the child object that exists at that position and all
+		 *   higher positions are moved up one position in the child list.
+		 * @return	The DisplayObject instance that you pass in the 
+		 *   child parameter.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 * @throws	SecurityError Calling the addChildAt() method of a Stage object throws an exception for
+		 *   any caller that is not in the same security sandbox as the Stage owner (the main SWF file).
+		 *   To avoid this, the Stage owner can grant permission to the domain of the caller by calling 
+		 *   the Security.allowDomain() method or the Security.allowInsecureDomain() method.
+		 *   For more information, see the "Security" chapter in the ActionScript 3.0 Developer's Guide.
+		 */
+		override public function addChildAt(child:DisplayObject, index:int):DisplayObject 
+		{
+			return super.addChildAt(child, index);
+		}
+
+		/**
+		 * Registers an event listener object with an EventDispatcher object so that the listener 
+		 * receives notification of an event. You can register event listeners on all nodes in the 
+		 * display list for a specific type of event, phase, and priority.After you successfully register an event listener, you cannot change its priority
+		 * through additional calls to addEventListener(). To change a listener's
+		 * priority, you must first call removeListener(). Then you can register the
+		 * listener again with the new priority level. Keep in mind that after the listener is registered, subsequent calls to
+		 * addEventListener() with a different type or
+		 * useCapture value result in the creation of a separate listener registration. 
+		 * For example, if you first register a listener with useCapture set to 
+		 * true, it listens only during the capture phase. If you call 
+		 * addEventListener() again using the same listener object, but with
+		 * useCapture set to false, you have two separate listeners: one
+		 * that listens during the capture phase and another that listens during the target and
+		 * bubbling phases.You cannot register an event listener for only the target phase or the bubbling 
+		 * phase. Those phases are coupled during registration because bubbling 
+		 * applies only to the ancestors of the target node.If you no longer need an event listener, remove it by calling 
+		 * removeEventListener(), or memory problems could result. Event listeners are not automatically
+		 * removed from memory because the garbage
+		 * collector does not remove the listener as long as the dispatching object exists (unless the useWeakReference
+		 * parameter is set to true).Copying an EventDispatcher instance does not copy the event listeners attached to it. 
+		 * (If your newly created node needs an event listener, you must attach the listener after
+		 * creating the node.) However, if you move an EventDispatcher instance, the event listeners 
+		 * attached to it move along with it.If the event listener is being registered on a node while an event is being processed
+		 * on this node, the event listener is not triggered during the current phase but can be 
+		 * triggered during a later phase in the event flow, such as the bubbling phase.If an event listener is removed from a node while an event is being processed on the node,
+		 * it is still triggered by the current actions. After it is removed, the event listener is
+		 * never invoked again (unless registered again for future processing).
+		 * @param	type	The type of event.
+		 * @param	listener	The listener function that processes the event. This function must accept
+		 *   an Event object as its only parameter and must return nothing, as this example shows:
+		 *   <codeblock>
+		 *   function(evt:Event):void
+		 *   </codeblock>
+		 *   The function can have any name.
+		 * @param	useCapture	Determines whether the listener works in the capture phase or the 
+		 *   target and bubbling phases. If useCapture is set to true, 
+		 *   the listener processes the event only during the capture phase and not in the 
+		 *   target or bubbling phase. If useCapture is false, the
+		 *   listener processes the event only during the target or bubbling phase. To listen for
+		 *   the event in all three phases, call addEventListener twice, once with 
+		 *   useCapture set to true, then again with
+		 *   useCapture set to false.
+		 * @param	priority	The priority level of the event listener. The priority is designated by
+		 *   a signed 32-bit integer. The higher the number, the higher the priority. All listeners
+		 *   with priority n are processed before listeners of priority n-1. If two
+		 *   or more listeners share the same priority, they are processed in the order in which they
+		 *   were added. The default priority is 0.
+		 * @param	useWeakReference	Determines whether the reference to the listener is strong or
+		 *   weak. A strong reference (the default) prevents your listener from being garbage-collected.
+		 *   A weak reference does not. Class-level member functions are not subject to garbage 
+		 *   collection, so you can set useWeakReference to true for 
+		 *   class-level member functions without subjecting them to garbage collection. If you set
+		 *   useWeakReference to true for a listener that is a nested inner 
+		 *   function, the function will be garbage-collected and no longer persistent. If you create 
+		 *   references to the inner function (save it in another variable) then it is not 
+		 *   garbage-collected and stays persistent.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 * @throws	SecurityError Calling the addEventListener method of a Stage object throws an exception for 
+		 *   any caller that is not in the same security sandbox as the Stage owner (the main SWF file).
+		 *   To avoid this situation, the Stage owner can grant permission to the domain of the caller by calling 
+		 *   the Security.allowDomain() method or the Security.allowInsecureDomain() method.
+		 *   For more information, see the "Security" chapter in the ActionScript 3.0 Developer's Guide.
+		 */
+		override public function addEventListener(type:String, listener:Function, useCapture:Boolean = false, priority:int = 0, useWeakReference:Boolean = false):void 
+		{
+			super.addEventListener(type, listener, useCapture, priority, useWeakReference);
+		}
+
+		/**
+		 * Dispatches an event into the event flow. The event target is the EventDispatcher 
+		 * object upon which the dispatchEvent() method is called.
+		 * @param	event	The Event object that is dispatched into the event flow.
+		 *   If the event is being redispatched, a clone of the event is created automatically.
+		 *   After an event is dispatched, its target property cannot be changed, so you
+		 *   must create a new copy of the event for redispatching to work.
+		 * @return	A value of true if the event was successfully dispatched. A value of false indicates failure or that preventDefault() was called 
+		 *   on the event.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 * @throws	SecurityError Calling the dispatchEvent() method of a Stage object throws an exception for 
+		 *   any caller that is not in the same security sandbox as the Stage owner (the main SWF file).
+		 *   To avoid this, the Stage owner can grant permission to the domain of the caller by calling 
+		 *   the Security.allowDomain() method or the Security.allowInsecureDomain() method.
+		 *   For more information, see the "Security" chapter in the ActionScript 3.0 Developer's Guide.
+		 */
+		override public function dispatchEvent(event:Event):Boolean 
+		{
+			return super.dispatchEvent(event);
+		}
+
+		/**
+		 * Checks whether the EventDispatcher object has any listeners registered for a specific type 
+		 * of event. This allows you to determine where an EventDispatcher object has altered
+		 * handling of an event type in the event flow hierarchy. To determine whether a specific
+		 * event type actually triggers an event listener, use willTrigger().
+		 * 
+		 *   The difference between hasEventListener() and willTrigger() 
+		 * is that hasEventListener() examines only the object to 
+		 * which it belongs, whereas willTrigger() examines the entire 
+		 * event flow for the event specified by the type parameter.
+		 * 
+		 *   When hasEventListener() is called from a LoaderInfo object, only the 
+		 * listeners that the caller can access are considered.
+		 * @param	type	The type of event.
+		 * @return	A value of true if a listener of the specified type is registered; 
+		 *   false otherwise.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 * @throws	SecurityError Calling the hasEventListener() method of a Stage object throws an exception for 
+		 *   any caller that is not in the same security sandbox as the Stage owner (the main SWF file).
+		 *   To avoid this, the Stage owner can grant permission to the domain of the caller by calling 
+		 *   the Security.allowDomain() method or the Security.allowInsecureDomain() method.
+		 *   For more information, see the "Security" chapter in the ActionScript 3.0 Developer's Guide.
+		 */
+		override public function hasEventListener(type:String):Boolean 
+		{
+			return super.hasEventListener(type);
+		}
+
+		/**
+		 * Calling the invalidate() method signals Flash runtimes to alert display objects 
+		 * on the next opportunity it has to render the display list (for example, when the playhead 
+		 * advances to a new frame). After you call the invalidate() method, when the display 
+		 * list is next rendered, the Flash runtime sends a render event to each display object that has 
+		 * registered to listen for the render event. You must call the invalidate() 
+		 * method each time you want the Flash runtime to send render events.
+		 * 
+		 *   The render event gives you an opportunity to make changes to the display list 
+		 * immediately before it is actually rendered. This lets you defer updates to the display list until the 
+		 * latest opportunity. This can increase performance by eliminating unnecessary screen updates.The render event is dispatched only to display objects that are in the same 
+		 * security domain as the code that calls the stage.invalidate() method, 
+		 * or to display objects from a security domain that has been granted permission via the 
+		 * Security.allowDomain() method.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 */
+		public function invalidate ():void
+		{
+			
+		}
+
+		/**
+		 * Determines whether the Stage.focus property returns null for 
+		 * security reasons.
+		 * In other words, isFocusInaccessible returns true if the 
+		 * object that has focus belongs to a security sandbox to which the SWF file does not have access.
+		 * @return	true if the object that has focus belongs to a security sandbox to which
+		 *   the SWF file does not have access.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 */
+		public function isFocusInaccessible ():Boolean
+		{
+			return null;
+		}
+
+		/**
+		 * Removes a child DisplayObject from the specified index position in the child list of 
+		 * the DisplayObjectContainer. The parent property of the removed child is set to 
+		 * null, and the object is garbage collected if no other references to the child exist. The index  
+		 * positions of any display objects above the child in the DisplayObjectContainer are decreased by 1.
+		 * 
+		 *   The garbage collector reallocates unused memory space. When a variable or
+		 * object is no longer actively referenced or stored somewhere, the garbage collector sweeps 
+		 * through and wipes out the memory space it used to occupy if no other references to it exist.
+		 * @param	index	The child index of the DisplayObject to remove.
+		 * @return	The DisplayObject instance that was removed.
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 * @throws	SecurityError Calling the removeChildAt() method of a Stage object throws an exception for
+		 *   any caller that is not in the same security sandbox as the object to be removed. To avoid this, 
+		 *   the owner of that object can grant permission to the domain of the caller by calling 
+		 *   the Security.allowDomain() method or the Security.allowInsecureDomain() method.
+		 *   For more information, see the "Security" chapter in the ActionScript 3.0 Developer's Guide.
+		 */
+		override public function removeChildAt(i:int):DisplayObject 
+		{
+			return super.removeChildAt(i);
+		}
+
+		/**
+		 * Changes the  position of an existing child in the display object container.
+		 * This affects the layering of child objects. For example, the following example shows three 
+		 * display objects, labeled a, b, and c, at index positions 0, 1, and 2, respectively:
+		 * 
+		 *   When you use the setChildIndex() method and specify an index position
+		 * that is already occupied, the only positions that change are those in between the display object's former and new position. 
+		 * All others will stay the same. 
+		 * If a child is moved to an index LOWER than its current index, all children in between will INCREASE by 1 for their index reference.
+		 * If a child is moved to an index HIGHER than its current index, all children in between will DECREASE by 1 for their index reference.
+		 * For example, if the display object container
+		 * in the previous example is named container, you can swap the position 
+		 * of the display objects labeled a and b by calling the following code:
+		 * <codeblock>
+		 * container.setChildIndex(container.getChildAt(1), 0);
+		 * </codeblock>
+		 * This code results in the following arrangement of objects:
+		 * @param	child	The child DisplayObject instance for which you want to change
+		 *   the index number.
+		 * @param	index	The resulting index number for the child display object.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 * @throws	SecurityError Calling the setChildIndex() method of a Stage object throws an exception for
+		 *   any caller that is not in the same security sandbox as the Stage owner (the main SWF file).
+		 *   To avoid this, the Stage owner can grant permission to the domain of the caller by calling 
+		 *   the Security.allowDomain() method or the Security.allowInsecureDomain() method.
+		 *   For more information, see the "Security" chapter in the ActionScript 3.0 Developer's Guide.
+		 */
+		override public function setChildIndex(child:DisplayObject, index:int):void 
+		{
+			super.setChildIndex(child, index);
+		}
+		
+		override public function swapChildrenAt(i1:int, i2:int):void 
+		{
+			super.swapChildrenAt(i1, i2);
+		}
+
+		/**
+		 * Checks whether an event listener is registered with this EventDispatcher object or any of 
+		 * its ancestors for the specified event type. This method returns true if an 
+		 * event listener is triggered during any phase of the event flow when an event of the 
+		 * specified type is dispatched to this EventDispatcher object or any of its descendants.
+		 * 
+		 *   The difference between the hasEventListener() and the willTrigger() 
+		 * methods is that hasEventListener() examines only the object to which it belongs, 
+		 * whereas the willTrigger() method examines the entire event flow for the event specified by the
+		 * type parameter. When willTrigger() is called from a LoaderInfo object, only the 
+		 * listeners that the caller can access are considered.
+		 * @param	type	The type of event.
+		 * @return	A value of true if a listener of the specified type will be triggered; false otherwise.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @throws	SecurityError Calling the willTrigger() method of a Stage object throws an exception for
+		 *   any caller that is not in the same security sandbox as the Stage owner (the main SWF file).
+		 *   To avoid this, the Stage owner can grant permission to the domain of the caller by calling 
+		 *   the Security.allowDomain() method or the Security.allowInsecureDomain() method.
+		 *   For more information, see the "Security" chapter in the ActionScript 3.0 Developer's Guide.
+		 */
+		override public function willTrigger(param1:String):Boolean 
+		{
+			return super.willTrigger(param1);
+		}
+		
+
+		
+		/************************ <Non Flash API Helper Methods> *****************************************/
+		public function get loaderInfo():LoaderInfo  { return _loaderInfo; }
 		
 		public function get canvas():HTMLCanvasElement
 		{
@@ -284,6 +1506,7 @@ package flash.display
 				}
 			}
 		}
+		
 		private function canvas_keyevent(e:Object):void {
 			var jsType:String = e.type;
 			var flashType:String;
@@ -299,6 +1522,7 @@ package flash.display
 				dispatchEvent(new KeyboardEvent(flashType, true, false, e.charCode, e.keyCode, e.location, e.ctrlKey, e.altKey, e.shiftKey));
 			}
 		}
+		
 		private function canvas_mouseevent(e:Object):void
 		{
 			var jsType:String = e.type;
@@ -351,6 +1575,7 @@ package flash.display
 				}
 			}
 		}
+		
 		/**
 		 * @flexjsignorecoercion CanvasRenderingContext2D
 		 */
@@ -380,17 +1605,6 @@ package flash.display
 			return _ctx2d;
 		}
 		
-		public function get displayContextInfo():String  { return null }
-		
-		public function get mouseX():Number 
-		{
-			return _mouseX;
-		}
-		
-		public function get mouseY():Number 
-		{
-			return _mouseY;
-		}
-	
+		/************************ </Non Flash API Helper Methods> *****************************************/
 	}
 }

--- a/src/flash/display/StageScaleMode.as
+++ b/src/flash/display/StageScaleMode.as
@@ -1,19 +1,47 @@
 package flash.display
 {
-   public final class StageScaleMode extends Object
-   {
-      
-      public static const SHOW_ALL:String = "showAll";
-      
-      public static const EXACT_FIT:String = "exactFit";
-      
-      public static const NO_BORDER:String = "noBorder";
-      
-      public static const NO_SCALE:String = "noScale";
-       
-      public function StageScaleMode()
-      {
-         super();
-      }
-   }
+	/**
+	 * The StageScaleMode class provides values for the <codeph class="+ topic/ph pr-d/codeph ">Stage.scaleMode</codeph> property.
+	 * @langversion	3.0
+	 * @playerversion	Flash 9
+	 * @playerversion	Lite 4
+	 */
+	public final class StageScaleMode extends Object
+	{
+		/**
+		 * Specifies that the entire application be visible in the specified area without trying to preserve 
+		 * the original aspect ratio. Distortion can occur.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 */
+		public static const EXACT_FIT : String = "exactFit";
+
+		/**
+		 * Specifies that the entire application fill the specified area, without distortion but possibly with 
+		 * some cropping, while maintaining the original aspect ratio of the application.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 */
+		public static const NO_BORDER : String = "noBorder";
+
+		/**
+		 * Specifies that the size of the application be fixed, so that it remains unchanged even as the size 
+		 * of the player window changes. Cropping might occur if the player window is smaller than the content.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 */
+		public static const NO_SCALE : String = "noScale";
+
+		/**
+		 * Specifies that the entire application be visible in the specified area without distortion while 
+		 * maintaining the original aspect ratio of the application. Borders can appear on two sides of the application.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 * @playerversion	Lite 4
+		 */
+		public static const SHOW_ALL : String = "showAll";
+	}
 }

--- a/src/flash/events/EventDispatcher.as
+++ b/src/flash/events/EventDispatcher.as
@@ -4,7 +4,7 @@ package flash.events
 	
 	[Event(name = "deactivate", type = "flash.events.Event")]
 	[Event(name = "activate", type = "flash.events.Event")]
-	public class EventDispatcher implements IEventDispatcher
+	public class EventDispatcher extends Object implements IEventDispatcher
 	{
 		private var listeners:Object = {};
 		

--- a/src/flash/geom/FMatrix.as
+++ b/src/flash/geom/FMatrix.as
@@ -22,7 +22,7 @@ package flash.geom
 			f[5] = ty;
 		}
 		
-		public function clone():Matrix
+		/*public function clone():Matrix
 		{
 			return new Matrix(f[0], f[1], f[2], f[3], f[4], f[5]);
 		}
@@ -251,7 +251,7 @@ package flash.geom
 				c = vector3D.y;
 				tx = vector3D.z;
 			}
-		}
+		}*/
 		
 	}
 

--- a/src/flash/net/Socket.as
+++ b/src/flash/net/Socket.as
@@ -15,9 +15,11 @@ package flash.net
 			websocket = new WebSocket("ws://"+host+":"+port);
 			//websocket.onclose
 		}
+		/*
 		public function get bytesAvailable () : uint{
 			
 		}
+		
 		public function get bytesPending () : uint;
 		public function get connected () : Boolean;
 		public function get endian () : String;
@@ -54,6 +56,6 @@ package flash.net
 		public function writeShort (value:int) : void;
 		public function writeUnsignedInt (value:uint) : void;
 		public function writeUTF (value:String) : void;
-		public function writeUTFBytes (value:String) : void;
+		public function writeUTFBytes (value:String) : void;*/
 	}
 }

--- a/src/flash/ui/ContextMenu.as
+++ b/src/flash/ui/ContextMenu.as
@@ -1,0 +1,260 @@
+package flash.ui
+{
+	import flash.display.NativeMenu;
+	import flash.ui.ContextMenuBuiltInItems;
+	import flash.net.URLRequest;
+	import flash.ui.ContextMenuClipboardItems;
+	import flash.ui.ContextMenu;
+
+	/**
+	 * Dispatched when a user first generates a 
+	 * context menu but before the contents of the context menu are displayed.
+	 * @eventType	flash.events.ContextMenuEvent.MENU_SELECT
+	 */
+	[Event(name="menuSelect", type="flash.events.ContextMenuEvent")] 
+
+	/**
+	 * The ContextMenu class provides control over the items displayed in context menus.
+	 * 
+	 *   <p class="- topic/p "><b class="+ topic/ph hi-d/b ">Mobile Browser Support:</b> This class is not supported in mobile browsers.</p><p class="- topic/p "><i class="+ topic/ph hi-d/i ">AIR profile support:</i> This feature is not supported 
+	 * on mobile devices or AIR for TV devices. See 
+	 * <xref href="http://help.adobe.com/en_US/air/build/WS144092a96ffef7cc16ddeea2126bb46b82f-8000.html" class="- topic/xref ">
+	 * AIR Profile Support</xref> for more information regarding API support across multiple profiles.</p><p class="- topic/p ">In Flash Player, users open the context menu by right-clicking (Windows or Linux) or Control-clicking 
+	 * (Macintosh) Flash Player. You can use the methods and properties of the ContextMenu class to 
+	 * add custom menu items, control the display of the built-in context menu items (for example, Zoom In, 
+	 * and Print), or create copies of menus. In AIR, there are no built-in items and no standard context menu.</p><p class="- topic/p ">In Flash Professional, you can attach a ContextMenu object to a specific button, movie clip, or text
+	 * field object, or to an entire movie level. You use the <codeph class="+ topic/ph pr-d/codeph ">contextMenu</codeph> property of the InteractiveObject
+	 * class to do this.</p><p class="- topic/p ">In Flex or Flash Builder, only top-level components in the application can have context menus.
+	 * For example, if a DataGrid control is a child of a TabNavigator or VBox container, the DataGrid control
+	 * cannot have its own context menu.</p><p class="- topic/p ">To add new items to a ContextMenu object, you create a ContextMenuItem object, and then add that
+	 * object to the <codeph class="+ topic/ph pr-d/codeph ">ContextMenu.customItems</codeph> array. For more information about creating context
+	 * menu items, see the ContextMenuItem class entry.</p><p class="- topic/p ">Flash Player has three types of context menus: the standard menu (which appears when you right-click
+	 * in Flash Player), the edit menu (which appears when you right-click a selectable or editable text
+	 * field), and an error menu (which appears when a SWF file has failed to load into Flash Player). Only the
+	 * standard and edit menus can be modified with the ContextMenu class. Only the edit menu appears in AIR.</p><p class="- topic/p ">Custom menu items always appear at the top of the Flash Player context menu, above any visible
+	 * built-in menu items; a separator bar distinguishes built-in and custom menu items. You cannot remove the 
+	 * Settings menu item from the context menu.
+	 * The Settings menu item is required in Flash so that users can access the settings that affect privacy and
+	 * storage on their computers. You also cannot remove the About menu item, which is
+	 * required so that users can find out what version of Flash Player they are using. (In AIR, the built-in 
+	 * Settings and About menu items are not used.)</p><p class="- topic/p ">You can add no more than 15 custom items to a context menu in Flash Player. In AIR, there is no explicit 
+	 * limit imposed on the number of items in a context menu.</p><p class="- topic/p ">You must use the <codeph class="+ topic/ph pr-d/codeph ">ContextMenu()</codeph> constructor to create a ContextMenu object before
+	 * calling its methods.</p>
+	 * 
+	 *   EXAMPLE:
+	 * 
+	 *   The following example uses the class <codeph class="+ topic/ph pr-d/codeph ">ContextMenuExample</codeph> 
+	 * to remove the default context menu items from the Stage and add a new menu item, which, if
+	 * clicked, changes the color of a square on the Stage.  This is accomplished with the following
+	 * steps:
+	 * <ol class="- topic/ol "><li class="- topic/li ">A property <codeph class="+ topic/ph pr-d/codeph ">myContextMenu</codeph> is declared and then assigned to a new ContextMenu
+	 * object and a property <codeph class="+ topic/ph pr-d/codeph ">redRectangle</codeph> of type Sprite is declared.</li><li class="- topic/li ">The method <codeph class="+ topic/ph pr-d/codeph ">removeDefaultItems()</codeph> is called, which removes all built-in context
+	 * menu items except Print.</li><li class="- topic/li ">The method <codeph class="+ topic/ph pr-d/codeph ">addCustomMenuItems()</codeph> is called, which places a menu item called 
+	 * <codeph class="+ topic/ph pr-d/codeph ">Red to Black</codeph> menu selection into the <codeph class="+ topic/ph pr-d/codeph ">defaultItems</codeph> array by using the 
+	 * <codeph class="+ topic/ph pr-d/codeph ">push()</codeph> method of Array.  A <codeph class="+ topic/ph pr-d/codeph ">menuItemSelect</codeph> event listener is added to the 
+	 * ContextMenuItem object and the associated method is called <codeph class="+ topic/ph pr-d/codeph ">menuItemSelectHandler()</codeph>.  
+	 * This method prints out some statements using <codeph class="+ topic/ph pr-d/codeph ">trace()</codeph> whenever the 
+	 * context menu is accessed and <codeph class="+ topic/ph pr-d/codeph ">Red to Black</codeph> is selected.  Also the red square
+	 * is removed and replaced with a black one.</li><li class="- topic/li ">An event listener of type <codeph class="+ topic/ph pr-d/codeph ">menuSelect</codeph> is added, along with
+	 * the associated method <codeph class="+ topic/ph pr-d/codeph ">menuSelectHandler</codeph>, which simply prints out three statements using
+	 * <codeph class="+ topic/ph pr-d/codeph ">trace()</codeph> every time an item in the context menu is opened.</li><li class="- topic/li ">Then <codeph class="+ topic/ph pr-d/codeph ">addChildren()</codeph> draws a red square and adds it
+	 * to the display list, where it is immediately displayed.</li><li class="- topic/li ">Finally, <codeph class="+ topic/ph pr-d/codeph ">myContextMenu</codeph> is assigned to the context menu of the <codeph class="+ topic/ph pr-d/codeph ">redRectangle</codeph> sprite
+	 * so that the custom context menu is displayed only when the mouse pointer is over the square.</li></ol><codeblock xml:space="preserve" class="+ topic/pre pr-d/codeblock ">
+	 * package {
+	 * import flash.ui.ContextMenu;
+	 * import flash.ui.ContextMenuItem;
+	 * import flash.ui.ContextMenuBuiltInItems;
+	 * import flash.events.ContextMenuEvent;
+	 * import flash.display.Sprite;
+	 * import flash.display.Shape;
+	 * import flash.text.TextField;
+	 * 
+	 *   public class ContextMenuExample extends Sprite {
+	 * private var myContextMenu:ContextMenu;
+	 * private var menuLabel:String = "Reverse Colors";
+	 * private var textLabel:String = "Right Click";
+	 * private var redRectangle:Sprite;
+	 * private var label:TextField;
+	 * private var size:uint = 100;
+	 * private var black:uint = 0x000000;
+	 * private var red:uint = 0xFF0000;
+	 * 
+	 *   public function ContextMenuExample() {
+	 * myContextMenu = new ContextMenu();
+	 * removeDefaultItems();
+	 * addCustomMenuItems();
+	 * myContextMenu.addEventListener(ContextMenuEvent.MENU_SELECT, menuSelectHandler);
+	 * 
+	 *   addChildren();
+	 * redRectangle.contextMenu = myContextMenu;
+	 * }
+	 * 
+	 *   private function addChildren():void {
+	 * redRectangle = new Sprite();
+	 * redRectangle.graphics.beginFill(red);
+	 * redRectangle.graphics.drawRect(0, 0, size, size);
+	 * addChild(redRectangle);
+	 * redRectangle.x = size;
+	 * redRectangle.y = size;
+	 * label = createLabel();
+	 * redRectangle.addChild(label);
+	 * }
+	 * 
+	 *   private function removeDefaultItems():void {
+	 * myContextMenu.hideBuiltInItems();
+	 * var defaultItems:ContextMenuBuiltInItems = myContextMenu.builtInItems;
+	 * defaultItems.print = true;
+	 * }
+	 * 
+	 *   private function addCustomMenuItems():void {
+	 * var item:ContextMenuItem = new ContextMenuItem(menuLabel);
+	 * myContextMenu.customItems.push(item);
+	 * item.addEventListener(ContextMenuEvent.MENU_ITEM_SELECT, menuItemSelectHandler);
+	 * }
+	 * 
+	 *   private function menuSelectHandler(event:ContextMenuEvent):void {
+	 * trace("menuSelectHandler: " + event);
+	 * }
+	 * 
+	 *   private function menuItemSelectHandler(event:ContextMenuEvent):void {
+	 * trace("menuItemSelectHandler: " + event);
+	 * var textColor:uint = (label.textColor == black) ? red : black;
+	 * var bgColor:uint = (label.textColor == black) ? black : red;
+	 * redRectangle.graphics.clear();
+	 * redRectangle.graphics.beginFill(bgColor);
+	 * redRectangle.graphics.drawRect(0, 0, size, size);
+	 * label.textColor = textColor;
+	 * }
+	 * 
+	 *   private function createLabel():TextField {
+	 * var txtField:TextField = new TextField();
+	 * txtField.text = textLabel;
+	 * return txtField;
+	 * }
+	 * }
+	 * }
+	 * </codeblock>
+	 * @langversion	3.0
+	 * @playerversion	Flash 9
+	 */
+	public final class ContextMenu extends NativeMenu
+	{
+		private var _builtInItems:ContextMenuBuiltInItems;
+		private var _clipboardItems:ContextMenuClipboardItems;
+		private var _clipboardMenu:Boolean = false;
+		private var _customItems:Array = [];
+		private var _link:URLRequest;
+		
+		private static var _isSupported:Boolean = true;
+		/**
+		 * An instance of the ContextMenuBuiltInItems class with the following properties: 
+		 * forwardAndBack, loop,
+		 * play, print, quality,
+		 * rewind, save, and zoom.
+		 * Setting these properties to false removes the corresponding menu items from the
+		 * specified ContextMenu object. These properties are enumerable and are set to true by
+		 * default.
+		 * 
+		 *   Note: In AIR, context menus do not have built-in items.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 */
+		public function get builtInItems () : flash.ui.ContextMenuBuiltInItems { return _builtInItems; }
+		public function set builtInItems (value:ContextMenuBuiltInItems) : void { _builtInItems = value; }
+
+		/**
+		 * An instance of the ContextMenuClipboardItems class with the following properties: 
+		 * cut, copy, paste, delete, selectAll.
+		 * Setting one of these properties to false disables the corresponding item in the
+		 * clipboard menu.
+		 * @langversion	3.0
+		 * @playerversion	Flash 10
+		 * @playerversion	AIR 1.5
+		 */
+		public function get clipboardItems () : flash.ui.ContextMenuClipboardItems { return _clipboardItems; }
+		public function set clipboardItems (value:ContextMenuClipboardItems) : void { _clipboardItems = value; }
+
+		/**
+		 * Specifies whether or not the clipboard menu should be used.  If this value is true,
+		 * the clipboardItems property determines which items are enabled or disabled on the clipboard menu.
+		 * 
+		 *   If the link property is non-null, this clipBoardMenu property is ignored.
+		 * @langversion	3.0
+		 * @playerversion	Flash 10
+		 * @playerversion	AIR 1.5
+		 */
+		public function get clipboardMenu () : Boolean { return _clipboardMenu; }
+		public function set clipboardMenu (value:Boolean) : void { _clipboardMenu = value; }
+
+		/**
+		 * An array of ContextMenuItem objects. Each object in the array represents a context menu item that you
+		 * have defined. Use this property to add, remove, or modify these custom menu items.
+		 * 
+		 *   To add new menu items, you create a ContextMenuItem object and then add it to the
+		 * customItems array (for example, by using Array.push()). For more information about creating
+		 * menu items, see the ContextMenuItem class entry.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 */
+		public function get customItems () : Array { return _customItems; }
+		public function set customItems (value:Array) : void { _customItems = value; }
+
+		/**
+		 * The isSupported property is set to true if the 
+		 * ContextMenu class is supported on the current platform, otherwise it is
+		 * set to false.
+		 * @langversion	3.0
+		 * @playerversion	Flash 10.1
+		 * @playerversion	AIR 2
+		 */
+		public static function get isSupported():Boolean { return _isSupported; }
+
+		/**
+		 * The URLRequest of the link.  If this property is null, a normal context menu is displayed.
+		 * If this property is not null, the link context menu is displayed, and operates on the url specified.
+		 * 
+		 *   If a link is specified, the clipboardMenu property is ignored.The default value is null.
+		 * @langversion	3.0
+		 * @playerversion	Flash 10
+		 * @playerversion	AIR 1.5
+		 */
+		public function get link ():flash.net.URLRequest { return _link }
+		public function set link (value:URLRequest):void { _link = value; }
+
+		/**
+		 * Creates a copy of the menu and all items.
+		 * @playerversion	AIR 1.0
+		 */
+		public function clone():flash.display.NativeMenu
+		{
+			return null;
+		}
+
+		/**
+		 * Creates a ContextMenu object.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 */
+		public function ContextMenu()
+		{
+			
+		}
+
+		/**
+		 * Hides all built-in menu items (except Settings) in the specified ContextMenu object. If the debugger version of Flash
+		 * Player is running, the Debugging menu item appears, although it is dimmed for SWF files that
+		 * do not have remote debugging enabled.
+		 * 
+		 *   This method hides only menu items that appear in the standard context menu; it does not affect
+		 * items that appear in the edit and error menus. This method works by setting all the Boolean members of my_cm.builtInItems to false. You can selectively make a built-in item visible by setting its
+		 * corresponding member in my_cm.builtInItems to true.
+		 * Note: In AIR, context menus do not have built-in items. Calling this method will have no effect.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 */
+		public function hideBuiltInItems():void
+		{
+			
+		}
+	}
+}

--- a/src/flash/ui/ContextMenuBuiltInItems.as
+++ b/src/flash/ui/ContextMenuBuiltInItems.as
@@ -1,0 +1,157 @@
+package flash.ui
+{
+	import flash.ui.ContextMenuBuiltInItems;
+
+	/**
+	 * The ContextMenuBuiltInItems class describes the items that are built in to a context menu.
+	 * You can hide these items by using the <codeph class="+ topic/ph pr-d/codeph ">ContextMenu.hideBuiltInItems()</codeph> method.
+	 * 
+	 *   EXAMPLE:
+	 * 
+	 *   The following example uses the class <codeph class="+ topic/ph pr-d/codeph ">ContextMenuBuiltInItemsExample</codeph> 
+	 * to remove the normal context menu items from the stage and add a new menu item.  This is 
+	 * accomplished with the following steps:
+	 * <ol class="- topic/ol "><li class="- topic/li ">A property <codeph class="+ topic/ph pr-d/codeph ">myContextMenu</codeph> is declared and then assigned to a new ContextMenu
+	 * object.</li><li class="- topic/li ">The method <codeph class="+ topic/ph pr-d/codeph ">removeDefaultItems()</codeph> is called, which removes all built-in context
+	 * menu items except Print.</li><li class="- topic/li ">The method <codeph class="+ topic/ph pr-d/codeph ">addCustomMenuItems()</codeph> is called, which places a menu item called 
+	 * <codeph class="+ topic/ph pr-d/codeph ">Hello World</codeph> into the <codeph class="+ topic/ph pr-d/codeph ">customItems</codeph> array using the 
+	 * <codeph class="+ topic/ph pr-d/codeph ">push()</codeph> method of Array.</li><li class="- topic/li ">The <codeph class="+ topic/ph pr-d/codeph ">Hello World</codeph> menu item is then added to the Stage's context
+	 * menu item list.</li><li class="- topic/li ">A TextField object with the text "Right Click" is added to the center of the Stage
+	 * by using <codeph class="+ topic/ph pr-d/codeph ">addChild()</codeph> via <codeph class="+ topic/ph pr-d/codeph ">createLabel()</codeph>.</li></ol><codeblock xml:space="preserve" class="+ topic/pre pr-d/codeblock ">
+	 * package {
+	 * import flash.ui.ContextMenu;
+	 * import flash.ui.ContextMenuItem;
+	 * import flash.ui.ContextMenuBuiltInItems;
+	 * import flash.display.Sprite;
+	 * import flash.text.TextField;
+	 * 
+	 *   public class ContextMenuBuiltInItemsExample extends Sprite {
+	 * private var myContextMenu:ContextMenu;
+	 * 
+	 *   public function ContextMenuBuiltInItemsExample() {
+	 * myContextMenu = new ContextMenu();
+	 * removeDefaultItems();
+	 * addCustomMenuItems();
+	 * this.contextMenu = myContextMenu;
+	 * addChild(createLabel());
+	 * }
+	 * 
+	 *   private function removeDefaultItems():void {
+	 * myContextMenu.hideBuiltInItems();
+	 * 
+	 *   var defaultItems:ContextMenuBuiltInItems = myContextMenu.builtInItems;
+	 * defaultItems.print = true;
+	 * }
+	 * 
+	 *   private function addCustomMenuItems():void {
+	 * var item:ContextMenuItem = new ContextMenuItem("Hello World");
+	 * myContextMenu.customItems.push(item);
+	 * }
+	 * 
+	 *   private function createLabel():TextField {
+	 * var txtField:TextField = new TextField();
+	 * txtField.text = "Right Click";
+	 * txtField.x = this.stage.stageWidth/2 - txtField.width/2;
+	 * txtField.y = this.stage.stageHeight/2 - txtField.height/2;
+	 * return txtField;
+	 * }
+	 * }
+	 * }
+	 * </codeblock>
+	 * @langversion	3.0
+	 * @playerversion	Flash 9
+	 */
+	public final class ContextMenuBuiltInItems extends Object
+	{
+		private var _forwardAndBack:Boolean = false;
+		private var _loop:Boolean = false;
+		private var _play:Boolean = false;
+		private var _print:Boolean = false;
+		private var _quality:Boolean = false;
+		private var _rewind:Boolean = false;
+		private var _save:Boolean = false;
+		private var _zoom:Boolean = false;
+		
+		/**
+		 * Lets the user move forward or backward one frame in a SWF file at run time (does not 
+		 * appear for a single-frame SWF file).
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 */
+		public function get forwardAndBack():Boolean { return _forwardAndBack; }
+		public function set forwardAndBack (val:Boolean):void { _forwardAndBack = val; }
+
+		/**
+		 * Lets the user set a SWF file to start over automatically when it reaches the final 
+		 * frame (does not appear for a single-frame SWF file).
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 */
+		public function get loop():Boolean { return _loop; }
+		public function set loop (val:Boolean):void { _loop = val; }
+
+		/**
+		 * Lets the user start a paused SWF file (does not appear for a single-frame SWF file).
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 */
+		public function get play():Boolean { return _play; }
+		public function set play (val:Boolean):void { _play = val; }
+
+		/**
+		 * Lets the user send the displayed frame image to a printer.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 */
+		public function get print():Boolean { return _print; }
+		public function set print (val:Boolean):void { _print = val; }
+
+		/**
+		 * Lets the user set the resolution of the SWF file at run time.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 */
+		public function get quality():Boolean { return _quality; }
+		public function set quality (val:Boolean):void { _quality = val; }
+
+		/**
+		 * Lets the user set a SWF file to play from the first frame when selected, at any time (does not 
+		 * appear for a single-frame SWF file).
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 */
+		public function get rewind():Boolean { return _rewind; }
+		public function set rewind (val:Boolean):void { _rewind = val; }
+
+		/**
+		 * Lets the user with Shockmachine installed save a SWF file.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 */
+		public function get save():Boolean { return _save; }
+		public function set save (val:Boolean):void { _save = val; }
+
+		/**
+		 * Lets the user zoom in and out on a SWF file at run time.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 */
+		public function get zoom():Boolean { return _zoom; }
+		public function set zoom (val:Boolean):void { _zoom = val; }
+
+		public function clone():ContextMenuBuiltInItems
+		{
+			return null;
+		}
+
+		/**
+		 * Creates a new ContextMenuBuiltInItems object so that you can set the properties for Flash Player to display or hide each menu item.
+		 * @langversion	3.0
+		 * @playerversion	Flash 9
+		 */
+		public function ContextMenuBuiltInItems()
+		{
+			
+		}
+	}
+}

--- a/src/flash/ui/ContextMenuClipboardItems.as
+++ b/src/flash/ui/ContextMenuClipboardItems.as
@@ -1,0 +1,92 @@
+package flash.ui
+{
+	import flash.ui.ContextMenuClipboardItems;
+
+	/**
+	 * The ContextMenuClipboardItems class lets you enable or disable the commands in the clipboard context menu.
+	 * 
+	 *   <p class="- topic/p ">Enable or disable the context menu clipboard commands using the <codeph class="+ topic/ph pr-d/codeph ">clipboardItems</codeph> property of
+	 * the ContextMenu object. The <codeph class="+ topic/ph pr-d/codeph ">clipboardItems</codeph> property is an instance of this ContextMenuClipboardItems 
+	 * class. The clipboard context menu is shown in a context menu when the <codeph class="+ topic/ph pr-d/codeph ">clipboardMenu</codeph> property
+	 * of the context menu is <codeph class="+ topic/ph pr-d/codeph ">true</codeph>, unless the context menu is for a TextField object. TextField objects
+	 * control the display of the context menu and the state of its clipboard items automatically.</p>
+	 * @langversion	3.0
+	 * @playerversion	Flash 10
+	 * @playerversion	AIR 1.5
+	 */
+	public final class ContextMenuClipboardItems extends Object
+	{
+		private var _clear:Boolean = false;
+		private var _copy:Boolean = false;
+		private var _cut:Boolean = false;
+		private var _paste:Boolean = false;
+		private var _selectAll:Boolean = false;
+		
+		/**
+		 * Enables or disables the 'Delete' or 'Clear' item on the clipboard menu.
+		 * This should be enabled only if an object that can be cleared is selected.
+		 * @langversion	3.0
+		 * @playerversion	Flash 10
+		 * @playerversion	AIR 1.5
+		 */
+		public function get clear():Boolean { return _clear; }
+		public function set clear (val:Boolean):void { _clear = val; }
+
+		/**
+		 * Enables or disables the 'Copy' item on the clipboard menu.
+		 * This should be enabled only if an object that can be copied is selected.
+		 * @langversion	3.0
+		 * @playerversion	Flash 10
+		 * @playerversion	AIR 1.5
+		 */
+		public function get copy():Boolean { return _copy; }
+		public function set copy (val:Boolean):void { _copy = val; }
+
+		/**
+		 * Enables or disables the 'Cut' item on the clipboard menu.
+		 * This should be enabled only if an object that can be cut is selected.
+		 * @langversion	3.0
+		 * @playerversion	Flash 10
+		 * @playerversion	AIR 1.5
+		 */
+		public function get cut():Boolean { return _cut; }
+		public function set cut (val:Boolean):void { _cut = val; }
+
+		/**
+		 * Enables or disables the 'Paste' item on the clipboard menu.
+		 * This should be enabled only if pastable data is on the clipboard.
+		 * @langversion	3.0
+		 * @playerversion	Flash 10
+		 * @playerversion	AIR 1.5
+		 */
+		public function get paste():Boolean { return _paste; }
+		public function set paste (val:Boolean):void { _paste = val; }
+
+		/**
+		 * Enables or disables the 'Select All' item on the clipboard menu.
+		 * This should only be enabled in a context where a selection can be 
+		 * expanded to include all similar items, such as in a list or a text editing control.
+		 * @langversion	3.0
+		 * @playerversion	Flash 10
+		 * @playerversion	AIR 1.5
+		 */
+		public function get selectAll():Boolean { return _selectAll; }
+		public function set selectAll (val:Boolean):void { _selectAll = val; }
+
+		public function clone():ContextMenuClipboardItems
+		{
+			return null;
+		}
+
+		/**
+		 * Creates a new ContextMenuClipboardItems object.
+		 * @langversion	3.0
+		 * @playerversion	Flash 10
+		 * @playerversion	AIR 1.5
+		 */
+		public function ContextMenuClipboardItems()
+		{
+			
+		}
+	}
+}


### PR DESCRIPTION
Li Zhi, feel no obligation to merge this, but I hope it can help.

In an effort to duplicate the same structure as the flash api, a circular dependency needed to be corrected so Stage class can still extend DisplayObjectContainer.  Sprite now creates the Stage instance and passes it to DisplayObject as a static variable that is available when instantiating DisplayObject on it's own or extended.  Additionally some classes include documentation to further the duplication of the Flash API.  Minor error corrections have also been made for SWC generation.